### PR TITLE
build: enable push to dockerhub 

### DIFF
--- a/.conf/Dockerfile
+++ b/.conf/Dockerfile
@@ -28,8 +28,6 @@ COPY ./scripts/inject-dynamic-env.sh /docker-entrypoint.d/00-inject-dynamic-env.
 RUN chmod +x /docker-entrypoint.d/00-inject-dynamic-env.sh
 # Install bash for env variables inject script
 RUN apk update && apk add --no-cache bash
-# temp fix for CVE-2023-23916 and CVE-2023-0464
-RUN apk upgrade --no-cache curl libcurl libssl3 libcrypto3
 # Make nginx owner of /usr/share/nginx/html/ and change to nginx user
 RUN chown -R 101:101 /usr/share/nginx/html/
 USER 101

--- a/.conf/notice-registration.md
+++ b/.conf/notice-registration.md
@@ -1,6 +1,6 @@
 ## Notice for Docker image
 
-DockerHub: [https://hub.docker.com/r/tractusx/portal-registration](https://hub.docker.com/r/tractusx/portal-registration)
+DockerHub: [https://hub.docker.com/r/tractusx/portal-frontend-registration](https://hub.docker.com/r/tractusx/portal-frontend-registration)
 
 Eclipse Tractus-X product(s) installed within the image:
 

--- a/.conf/notice-registration.md
+++ b/.conf/notice-registration.md
@@ -1,0 +1,23 @@
+## Notice for Docker image
+
+DockerHub: [https://hub.docker.com/r/tractusx/portal-registration](https://hub.docker.com/r/tractusx/portal-registration)
+
+Eclipse Tractus-X product(s) installed within the image:
+
+__Portal Frontend Registration__
+
+- GitHub: https://github.com/eclipse-tractusx/portal-frontend-registration
+- Project home: https://projects.eclipse.org/projects/automotive.tractusx
+- Dockerfile: https://github.com/eclipse-tractusx/portal-frontend-registration/blob/main/.conf/Dockerfile
+- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/portal-frontend-registration/blob/main/LICENSE)
+
+__Used base images__
+
+- Dockerfile: [nginxinc/nginx-unprivileged:alpine](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/Dockerfile-alpine.template)
+- GitHub project: [https://github.com/nginxinc/docker-nginx-unprivileged](https://github.com/nginxinc/docker-nginx-unprivileged)
+- DockerHub: [https://hub.docker.com/r/nginxinc/nginx-unprivileged](https://hub.docker.com/r/nginxinc/nginx-unprivileged)
+
+As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies
+with any relevant licenses for all software contained within.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,22 +26,18 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-  COMMIT_SHA: ${{ github.sha }}
+  IMAGE_NAMESPACE: "tractusx"
+  IMAGE_NAME: "portal-frontend-registration"
 
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.ref }}
 
       - name: Install Dependencies
         run: yarn
@@ -55,28 +51,40 @@ jobs:
       - name: Unit Tests
         run: yarn test:ci
 
-      - name: Log in to the Container registry
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=dev
+            type=raw,value=${{ github.sha }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
           file: .conf/Dockerfile
-          push: true
-          # build tag :dev with commit-sha and latest
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.COMMIT_SHA }}, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      # https://github.com/peter-evans/dockerhub-description
+      - name: Update Docker Hub description
+        if: github.event_name != 'pull_request'
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+          readme-filepath: ".conf/notice-registration.md"
 
   auth-and-dispatch:
     needs: build-and-push-image
@@ -97,8 +105,8 @@ jobs:
         run: |
           curl -v \
             --request POST \
-            --url https://api.github.com/repos/catenax-ng/tx-portal-cd/actions/workflows/portal-registration-image-update.yml/dispatches \
+            --url https://api.github.com/repos/eclipse-tractusx/portal-cd/actions/workflows/portal-registration-image-update.yml/dispatches \
             --header "authorization: Bearer $TOKEN" \
             --header "Accept: application/vnd.github.v3+json" \
-            --data '{"ref":"helm-environments", "inputs": { "new-image":"${{ env.COMMIT_SHA }}" }}' \
+            --data '{"ref":"dev", "inputs": { "new-image":"${{ github.sha }}" }}' \
             --fail

--- a/.github/workflows/release-release_candidate.yml
+++ b/.github/workflows/release-release_candidate.yml
@@ -26,16 +26,14 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-  TAG_NAME: ${{ github.ref_name }}
+  IMAGE_NAMESPACE: "tractusx"
+  IMAGE_NAME: "portal-frontend-registration"
 
 jobs:
   build-and-push-release:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     steps:
       - name: Checkout repository
@@ -47,18 +45,18 @@ jobs:
 
       - name: Output versions
         run: |
-          echo git ${{ env.TAG_NAME }}
+          echo git ${{ github.ref_name }}
           echo npm ${{ steps.npm-tag.outputs.current-version }}
 
       - name: Versions not matching
-        if: env.TAG_NAME != steps.npm-tag.outputs.current-version
+        if: github.ref_name != steps.npm-tag.outputs.current-version
         run: |
           echo git and npm versions not equal - refusing to build release
           exit 1
 
       - name: Version match
         run: |
-          echo versions equal - building release ${{ env.TAG_NAME }}
+          echo versions equal - building release ${{ github.ref_name }}
 
       - name: Install Dependencies
         run: yarn
@@ -72,27 +70,40 @@ jobs:
       - name: Unit Tests
         run: yarn test:ci
 
-      - name: Log in to the Container registry
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ github.ref_name }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
           file: .conf/Dockerfile
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.TAG_NAME }}, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      # https://github.com/peter-evans/dockerhub-description
+      - name: Update Docker Hub description
+        if: github.event_name != 'pull_request'
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+          readme-filepath: ".conf/notice-registration.md"
 
   auth-and-dispatch:
     needs: build-and-push-release
@@ -100,7 +111,7 @@ jobs:
 
     steps:
       - name: Set env
-        run: echo "RELEASE_VERSION=${{ env.TAG_NAME }}" >> $GITHUB_ENV
+        run: echo "RELEASE_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
 
       - name: Get token
         id: get_workflow_token
@@ -116,8 +127,8 @@ jobs:
         run: |
           curl -v \
             --request POST \
-            --url https://api.github.com/repos/catenax-ng/tx-portal-cd/actions/workflows/portal-registration-release-image-update.yml/dispatches \
+            --url https://api.github.com/repos/eclipse-tractusx/portal-cd/actions/workflows/portal-registration-image-update.yml/dispatches \
             --header "authorization: Bearer $TOKEN" \
             --header "Accept: application/vnd.github.v3+json" \
-            --data '{"ref":"release-candidate", "inputs": { "new-image":"${{ env.RELEASE_VERSION }}" }}' \
+            --data '{"ref":"release-candidate", "inputs": { "new-image":"${{ github.ref_name }}" }}' \
             --fail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,16 +27,14 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-  TAG_NAME: ${{ github.ref_name }}
+  IMAGE_NAMESPACE: "tractusx"
+  IMAGE_NAME: "portal-frontend-registration"
 
 jobs:
   build-and-push-release:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     steps:
       - name: Checkout repository
@@ -48,18 +46,18 @@ jobs:
 
       - name: Output versions
         run: |
-          echo git ${{ env.TAG_NAME }}
+          echo git ${{ github.ref_name }}
           echo npm ${{ steps.npm-tag.outputs.current-version }}
 
       - name: Versions not matching
-        if: env.TAG_NAME != steps.npm-tag.outputs.current-version
+        if: github.ref_name != steps.npm-tag.outputs.current-version
         run: |
           echo git and npm versions not equal - refusing to build release
           exit 1
 
       - name: Version match
         run: |
-          echo versions equal - building release ${{ env.TAG_NAME }}
+          echo versions equal - building release ${{ github.ref_name }}
 
       - name: Install Dependencies
         run: yarn
@@ -73,27 +71,40 @@ jobs:
       - name: Unit Tests
         run: yarn test:ci
 
-      - name: Log in to the Container registry
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ github.ref_name }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
           file: .conf/Dockerfile
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.TAG_NAME }}, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      # https://github.com/peter-evans/dockerhub-description
+      - name: Update Docker Hub description
+        if: github.event_name != 'pull_request'
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+          readme-filepath: ".conf/notice-registration.md"
 
   auth-and-dispatch:
     needs: build-and-push-release
@@ -101,7 +112,7 @@ jobs:
 
     steps:
       - name: Set env
-        run: echo "RELEASE_VERSION=${{ env.TAG_NAME }}" >> $GITHUB_ENV
+        run: echo "RELEASE_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
 
       - name: Get token
         id: get_workflow_token
@@ -117,8 +128,8 @@ jobs:
         run: |
           curl -v \
             --request POST \
-            --url https://api.github.com/repos/catenax-ng/tx-portal-cd/actions/workflows/portal-registration-release-image-update.yml/dispatches \
+            --url https://api.github.com/repos/eclipse-tractusx/portal-cd/actions/workflows/portal-registration-image-update.yml/dispatches \
             --header "authorization: Bearer $TOKEN" \
             --header "Accept: application/vnd.github.v3+json" \
-            --data '{"ref":"helm-environments", "inputs": { "new-image":"${{ env.RELEASE_VERSION }}" }}' \
+            --data '{"ref":"dev", "inputs": { "new-image":"${{ github.ref_name }}" }}' \
             --fail

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -26,22 +26,18 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-  COMMIT_SHA: ${{ github.sha }}
+  IMAGE_NAMESPACE: "tractusx"
+  IMAGE_NAME: "portal-frontend-registration"
 
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.ref }}
 
       - name: Install Dependencies
         run: yarn
@@ -55,27 +51,40 @@ jobs:
       - name: Unit Tests
         run: yarn test:ci
 
-      - name: Log in to the Container registry
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=rc
+            type=raw,value=${{ github.sha }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
           file: .conf/Dockerfile
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.COMMIT_SHA }}, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:rc
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      # https://github.com/peter-evans/dockerhub-description
+      - name: Update Docker Hub description
+        if: github.event_name != 'pull_request'
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+          readme-filepath: ".conf/notice-registration.md"
 
   auth-and-dispatch:
     needs: build-and-push-image
@@ -96,8 +105,8 @@ jobs:
         run: |
           curl -v \
             --request POST \
-            --url https://api.github.com/repos/catenax-ng/tx-portal-cd/actions/workflows/portal-registration-rc-image-update.yml/dispatches \
+            --url https://api.github.com/repos/eclipse-tractusx/portal-cd/actions/workflows/portal-registration-image-update.yml/dispatches \
             --header "authorization: Bearer $TOKEN" \
             --header "Accept: application/vnd.github.v3+json" \
-            --data '{"ref":"release-candidate", "inputs": { "new-image":"${{ env.COMMIT_SHA }}" }}' \
+            --data '{"ref":"release-candidate", "inputs": { "new-image":"${{ github.sha }}" }}' \
             --fail

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ The Catena-X Portal application consists of
 
 The Catena-X Portal is designed to work with the [Catena-X IAM](https://github.com/eclipse-tractusx/portal-iam).
 
-* Dev Install: https://portal-dev.demo.catena-x.net/registration/
-
 ### Local build & run
 
 Run the application on your machine on http://localhost:3002/registration/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Catena-X Portal application consists of
 
 The Catena-X Portal is designed to work with the [Catena-X IAM](https://github.com/eclipse-tractusx/portal-iam).
 
-### Local build & run
+## Local build & run
 
 Run the application on your machine on http://localhost:3002/registration/
 
@@ -22,3 +22,20 @@ Note: if you'd like to run the complete frontend application, follow the 'Run fr
     yarn
     yarn build
     yarn start
+
+## Notice for Docker image
+
+This application provides container images for demonstration purposes.
+
+DockerHub: https://hub.docker.com/r/tractusx/portal-frontend-registration
+
+Base image: nginxinc/nginx-unprivileged:alpine
+
+* Dockerfile: [nginxinc/nginx-unprivileged:alpine](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/Dockerfile-alpine.template)
+* GitHub project: [https://github.com/nginxinc/docker-nginx-unprivileged](https://github.com/nginxinc/docker-nginx-unprivileged)
+* DockerHub: [https://hub.docker.com/r/nginxinc/nginx-unprivileged](https://hub.docker.com/r/nginxinc/nginx-unprivileged)
+
+## License
+
+Distributed under the Apache 2.0 License.
+See [LICENSE](./LICENSE) for more information.


### PR DESCRIPTION
## Description

- enable workflows for push to dockerhub
- change to tags from docker metadata action
- add notice for docker images and license in readme https://github.com/eclipse-tractusx/portal-frontend-registration/issues/17
- remove references to consortia envs from readme
- remove temporary security fixes

## Why

https://eclipse-tractusx.github.io/docs/release/trg-4/trg-4-05
https://eclipse-tractusx.github.io/docs/release/trg-4/trg-4-06