### PR TITLE
fix(legal-notice): remove space between commit id and colon

### DIFF
--- a/src/components/AboutCard.tsx
+++ b/src/components/AboutCard.tsx
@@ -119,7 +119,7 @@ export const AboutCard = (props: {
                   textAlign: 'left',
                 }}
               >
-                Commit ID : {props.commitId}
+                Commit ID: {props.commitId}
               </Typography>
             </Box>
           )}


### PR DESCRIPTION
## Description

remove space after commit id text

## Why

space is not necessary

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
