### PR TITLE
chore(workflows): add dependencies check and update release

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -1,0 +1,79 @@
+###############################################################
+# Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
+
+name: Check Dependencies
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+jobs:
+  check-dependencies:
+
+    runs-on: ubuntu-latest
+
+    steps:
+  
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Generate Dependencies file
+        run: java -jar ./scripts/download/org.eclipse.dash.licenses-1.0.2.jar yarn.lock -project automotive.tractusx -summary DEPENDENCIES
+
+      - name: Check if dependencies were changed
+        id: dependencies-changed
+        run: |
+          changed=$(git diff DEPENDENCIES)
+          if [[ -n "$changed" ]]; then
+            echo "dependencies changed"
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "dependencies not changed"
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check for restricted dependencies
+        run: |
+          restricted=$(grep ' restricted,' DEPENDENCIES || true)
+          if [[ -n "$restricted" ]]; then
+            echo "The following dependencies are restricted: $restricted"
+            exit 1
+          fi
+        if: steps.dependencies-changed.outputs.changed == 'true'
+
+      - name: Upload DEPENDENCIES file
+        uses: actions/upload-artifact@v3
+        with:
+          path: DEPENDENCIES
+        if: steps.dependencies-changed.outputs.changed == 'true'
+
+      - name: Signal need to update DEPENDENCIES
+        run: |
+          echo "Dependencies need to be updated (updated DEPENDENCIES file has been uploaded to workflow run)"
+          exit 1
+        if: steps.dependencies-changed.outputs.changed == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,8 +124,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Check for hotfix version
+        id: hf-check
+        run: |
+          hf=$(git ls-remote --heads origin "hotfix/${{ env.REF_NAME }}*")
+          if [[ -n "$hf" ]]; then
+            echo "hf=true" >> $GITHUB_OUTPUT
+          else
+            echo "hf=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Get tags
         run: git fetch --tags --force
+        if: steps.hf-check.outputs.hf == 'false'
 
       - name: Check for previous release candidate version
         id: rc-check
@@ -133,7 +144,10 @@ jobs:
           rc=$(git tag -l "${{ env.REF_NAME }}-RC*")
           if [[ -n "$rc" ]]; then
             echo "rc=true" >> $GITHUB_OUTPUT
+          else
+            echo "rc=false" >> $GITHUB_OUTPUT
           fi
+        if: steps.hf-check.outputs.hf == 'false'
 
       - name: Determine branch to update in portal-cd
         id: cd-branch
@@ -143,6 +157,7 @@ jobs:
           else
             echo "branch=dev" >> $GITHUB_OUTPUT
           fi
+        if: steps.hf-check.outputs.hf == 'false'
 
       - name: Get token
         id: get_workflow_token
@@ -150,6 +165,7 @@ jobs:
         with:
           application_id: ${{ secrets.ORG_PORTAL_DISPATCH_APPID }}
           application_private_key: ${{ secrets.ORG_PORTAL_DISPATCH_KEY }}
+        if: steps.hf-check.outputs.hf == 'false'
 
       - name: Trigger workflow
         id: call_action
@@ -163,3 +179,4 @@ jobs:
             --header "Accept: application/vnd.github.v3+json" \
             --data '{"ref":"${{ steps.cd-branch.outputs.branch }}", "inputs": { "new-image":"${{ env.REF_NAME }}" }}' \
             --fail
+        if: steps.hf-check.outputs.hf == 'false'

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,4664 +1,1330 @@
-yarn licenses v1.5.1
-info fsevents@2.3.2: The platform "linux" is incompatible with this module.
-info "fsevents@2.3.2" is an optional dependency and failed compatibility check. Excluding it from installation.
-├─ (AFL-2.1 OR BSD-3-Clause)
-│  └─ json-schema@0.4.0
-│     ├─ URL: http://github.com/kriszyp/json-schema
-│     └─ VendorName: Kris Zyp
-├─ (Apache-2.0 OR MIT)
-│  └─ vis@4.21.0-EOL
-│     ├─ URL: git://github.com/almende/vis.git
-│     └─ VendorUrl: http://visjs.org/
-├─ (Apache-2.0 OR MPL-1.1)
-│  └─ harmony-reflect@1.6.2
-│     ├─ URL: https://tvcutsem@github.com/tvcutsem/harmony-reflect.git
-│     └─ VendorUrl: https://github.com/tvcutsem/harmony-reflect
-├─ (BSD-3-Clause OR GPL-2.0)
-│  └─ node-forge@1.3.1
-│     ├─ URL: https://github.com/digitalbazaar/forge
-│     ├─ VendorName: Digital Bazaar, Inc.
-│     └─ VendorUrl: https://github.com/digitalbazaar/forge
-├─ (MIT OR CC0-1.0)
-│  ├─ type-fest@0.16.0
-│  │  ├─ URL: https://github.com/sindresorhus/type-fest.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ type-fest@0.20.2
-│  │  ├─ URL: https://github.com/sindresorhus/type-fest.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  └─ type-fest@0.21.3
-│     ├─ URL: https://github.com/sindresorhus/type-fest.git
-│     ├─ VendorName: Sindre Sorhus
-│     └─ VendorUrl: https://sindresorhus.com
-├─ 0BSD
-│  ├─ tslib@1.14.1
-│  │  ├─ URL: https://github.com/Microsoft/tslib.git
-│  │  ├─ VendorName: Microsoft Corp.
-│  │  └─ VendorUrl: https://www.typescriptlang.org/
-│  └─ tslib@2.5.0
-│     ├─ URL: https://github.com/Microsoft/tslib.git
-│     ├─ VendorName: Microsoft Corp.
-│     └─ VendorUrl: https://www.typescriptlang.org/
-├─ Apache-2.0
-│  ├─ @ampproject/remapping@2.2.0
-│  │  ├─ URL: git+https://github.com/ampproject/remapping.git
-│  │  └─ VendorName: Justin Ridgewell
-│  ├─ @humanwhocodes/config-array@0.11.8
-│  │  ├─ URL: git+https://github.com/humanwhocodes/config-array.git
-│  │  ├─ VendorName: Nicholas C. Zakas
-│  │  └─ VendorUrl: https://github.com/humanwhocodes/config-array#readme
-│  ├─ @humanwhocodes/config-array@0.5.0
-│  │  ├─ URL: git+https://github.com/humanwhocodes/config-array.git
-│  │  ├─ VendorName: Nicholas C. Zakas
-│  │  └─ VendorUrl: https://github.com/humanwhocodes/config-array#readme
-│  ├─ @humanwhocodes/module-importer@1.0.1
-│  │  ├─ URL: git+https://github.com/humanwhocodes/module-importer.git
-│  │  └─ VendorName: Nicholas C. Zaks
-│  ├─ @react-aria/ssr@3.4.1
-│  │  └─ URL: https://github.com/adobe/react-spectrum
-│  ├─ @surma/rollup-plugin-off-main-thread@2.2.3
-│  │  ├─ URL: https://github.com/surma/rollup-plugin-off-main-thread
-│  │  └─ VendorName: Surma
-│  ├─ @webassemblyjs/leb128@1.11.1
-│  │  └─ URL: https://github.com/xtuc/webassemblyjs.git
-│  ├─ @xtuc/long@4.2.2
-│  │  ├─ URL: https://github.com/dcodeIO/long.js.git
-│  │  └─ VendorName: Daniel Wirtz
-│  ├─ acorn-node@1.8.2
-│  │  ├─ URL: https://github.com/browserify/acorn-node.git
-│  │  ├─ VendorName: Renée Kooi
-│  │  └─ VendorUrl: https://github.com/browserify/acorn-node
-│  ├─ ansi-html-community@0.0.8
-│  │  ├─ URL: git://github.com/mahdyar/ansi-html-community.git
-│  │  ├─ VendorName: mahdyar
-│  │  └─ VendorUrl: https://github.com/mahdyar/ansi-html-community
-│  ├─ aria-query@5.1.3
-│  │  ├─ URL: git+https://github.com/A11yance/aria-query.git
-│  │  ├─ VendorName: Jesse Beach
-│  │  └─ VendorUrl: https://github.com/A11yance/aria-query#readme
-│  ├─ axobject-query@3.1.1
-│  │  ├─ URL: git+https://github.com/A11yance/axobject-query.git
-│  │  ├─ VendorName: Jesse Beach
-│  │  └─ VendorUrl: https://github.com/A11yance/axobject-query#readme
-│  ├─ bser@2.1.1
-│  │  ├─ URL: https://github.com/facebook/watchman
-│  │  ├─ VendorName: Wez Furlong
-│  │  └─ VendorUrl: https://facebook.github.io/watchman/docs/bser.html
-│  ├─ didyoumean@1.2.2
-│  │  ├─ URL: https://github.com/dcporter/didyoumean.js.git
-│  │  ├─ VendorName: Dave Porter
-│  │  └─ VendorUrl: https://github.com/dcporter/didyoumean.js
-│  ├─ doctrine@2.1.0
-│  │  ├─ URL: https://github.com/eslint/doctrine.git
-│  │  └─ VendorUrl: https://github.com/eslint/doctrine
-│  ├─ doctrine@3.0.0
-│  │  ├─ URL: https://github.com/eslint/doctrine.git
-│  │  └─ VendorUrl: https://github.com/eslint/doctrine
-│  ├─ ejs@3.1.8
-│  │  ├─ URL: git://github.com/mde/ejs.git
-│  │  ├─ VendorName: Matthew Eernisse
-│  │  └─ VendorUrl: https://github.com/mde/ejs
-│  ├─ eslint-visitor-keys@1.3.0
-│  │  ├─ URL: https://github.com/eslint/eslint-visitor-keys.git
-│  │  ├─ VendorName: Toru Nagashima
-│  │  └─ VendorUrl: https://github.com/eslint/eslint-visitor-keys#readme
-│  ├─ eslint-visitor-keys@2.1.0
-│  │  ├─ URL: https://github.com/eslint/eslint-visitor-keys.git
-│  │  ├─ VendorName: Toru Nagashima
-│  │  └─ VendorUrl: https://github.com/eslint/eslint-visitor-keys#readme
-│  ├─ eslint-visitor-keys@3.3.0
-│  │  ├─ URL: https://github.com/eslint/eslint-visitor-keys.git
-│  │  ├─ VendorName: Toru Nagashima
-│  │  └─ VendorUrl: https://github.com/eslint/eslint-visitor-keys#readme
-│  ├─ faye-websocket@0.11.4
-│  │  ├─ URL: git://github.com/faye/faye-websocket-node.git
-│  │  ├─ VendorName: James Coglan
-│  │  └─ VendorUrl: https://github.com/faye/faye-websocket-node
-│  ├─ fb-watchman@2.0.2
-│  │  ├─ URL: git@github.com:facebook/watchman.git
-│  │  ├─ VendorName: Wez Furlong
-│  │  └─ VendorUrl: https://facebook.github.io/watchman/
-│  ├─ filelist@1.0.4
-│  │  ├─ URL: git://github.com/mde/filelist.git
-│  │  ├─ VendorName: Matthew Eernisse
-│  │  └─ VendorUrl: https://github.com/mde/filelist
-│  ├─ fuse.js@3.6.1
-│  │  ├─ URL: https://github.com/krisk/Fuse.git
-│  │  ├─ VendorName: Kirollos Risk
-│  │  └─ VendorUrl: http://fusejs.io/
-│  ├─ human-signals@2.1.0
-│  │  ├─ URL: https://github.com/ehmicky/human-signals.git
-│  │  ├─ VendorName: ehmicky
-│  │  └─ VendorUrl: https://git.io/JeluP
-│  ├─ jake@10.8.5
-│  │  ├─ URL: git://github.com/jakejs/jake.git
-│  │  ├─ VendorName: Matthew Eernisse
-│  │  └─ VendorUrl: http://fleegix.org
-│  ├─ keycloak-js@15.1.1
-│  │  ├─ URL: https://github.com/keycloak/keycloak
-│  │  ├─ VendorName: Keycloak
-│  │  └─ VendorUrl: https://www.keycloak.org/
-│  ├─ typescript@4.9.5
-│  │  ├─ URL: https://github.com/Microsoft/TypeScript.git
-│  │  ├─ VendorName: Microsoft Corp.
-│  │  └─ VendorUrl: https://www.typescriptlang.org/
-│  ├─ walker@1.0.8
-│  │  ├─ URL: https://github.com/daaku/nodejs-walker
-│  │  ├─ VendorName: Naitik Shah
-│  │  └─ VendorUrl: https://github.com/daaku/nodejs-walker
-│  ├─ web-vitals@2.1.4
-│  │  ├─ URL: https://github.com/GoogleChrome/web-vitals.git
-│  │  ├─ VendorName: Philip Walton
-│  │  └─ VendorUrl: http://philipwalton.com
-│  ├─ websocket-driver@0.7.4
-│  │  ├─ URL: git://github.com/faye/websocket-driver-node.git
-│  │  ├─ VendorName: James Coglan
-│  │  └─ VendorUrl: https://github.com/faye/websocket-driver-node
-│  ├─ websocket-extensions@0.1.4
-│  │  ├─ URL: git://github.com/faye/websocket-extensions-node.git
-│  │  ├─ VendorName: James Coglan
-│  │  └─ VendorUrl: http://github.com/faye/websocket-extensions-node
-│  └─ xml-name-validator@3.0.0
-│     ├─ URL: https://github.com/jsdom/xml-name-validator.git
-│     ├─ VendorName: Domenic Denicola
-│     └─ VendorUrl: https://domenic.me/
-├─ BSD-2-Clause
-│  ├─ @typescript-eslint/parser@5.51.0
-│  │  └─ URL: https://github.com/typescript-eslint/typescript-eslint.git
-│  ├─ @typescript-eslint/typescript-estree@5.51.0
-│  │  └─ URL: https://github.com/typescript-eslint/typescript-eslint.git
-│  ├─ browser-process-hrtime@1.0.0
-│  │  ├─ URL: git://github.com/kumavis/browser-process-hrtime.git
-│  │  └─ VendorName: kumavis
-│  ├─ css-select@2.1.0
-│  │  ├─ URL: git://github.com/fb55/css-select.git
-│  │  └─ VendorName: Felix Boehm
-│  ├─ css-select@4.3.0
-│  │  ├─ URL: git://github.com/fb55/css-select.git
-│  │  └─ VendorName: Felix Boehm
-│  ├─ css-what@3.4.2
-│  │  ├─ URL: https://github.com/fb55/css-what
-│  │  ├─ VendorName: Felix Böhm
-│  │  └─ VendorUrl: http://feedic.com
-│  ├─ css-what@6.1.0
-│  │  ├─ URL: https://github.com/fb55/css-what
-│  │  ├─ VendorName: Felix Böhm
-│  │  └─ VendorUrl: http://feedic.com
-│  ├─ damerau-levenshtein@1.0.8
-│  │  ├─ URL: https://github.com/tad-lispy/node-damerau-levenshtein.git
-│  │  └─ VendorName: The Spanish Inquisition
-│  ├─ default-gateway@6.0.3
-│  │  ├─ URL: https://github.com/silverwind/default-gateway.git
-│  │  └─ VendorName: silverwind
-│  ├─ domelementtype@1.3.1
-│  │  ├─ URL: git://github.com/fb55/domelementtype.git
-│  │  └─ VendorName: Felix Boehm
-│  ├─ domelementtype@2.3.0
-│  │  ├─ URL: git://github.com/fb55/domelementtype.git
-│  │  └─ VendorName: Felix Boehm
-│  ├─ domhandler@4.3.1
-│  │  ├─ URL: git://github.com/fb55/domhandler.git
-│  │  └─ VendorName: Felix Boehm
-│  ├─ domutils@1.7.0
-│  │  ├─ URL: git://github.com/FB55/domutils.git
-│  │  └─ VendorName: Felix Boehm
-│  ├─ domutils@2.8.0
-│  │  ├─ URL: git://github.com/fb55/domutils.git
-│  │  └─ VendorName: Felix Boehm
-│  ├─ dotenv-expand@5.1.0
-│  │  └─ VendorName: motdotla
-│  ├─ dotenv@10.0.0
-│  │  └─ URL: git://github.com/motdotla/dotenv.git
-│  ├─ entities@2.2.0
-│  │  ├─ URL: git://github.com/fb55/entities.git
-│  │  └─ VendorName: Felix Boehm
-│  ├─ escodegen@2.0.0
-│  │  ├─ URL: http://github.com/estools/escodegen.git
-│  │  └─ VendorUrl: http://github.com/estools/escodegen
-│  ├─ eslint-scope@5.1.1
-│  │  ├─ URL: https://github.com/eslint/eslint-scope.git
-│  │  └─ VendorUrl: http://github.com/eslint/eslint-scope
-│  ├─ eslint-scope@7.1.1
-│  │  ├─ URL: https://github.com/eslint/eslint-scope.git
-│  │  └─ VendorUrl: http://github.com/eslint/eslint-scope
-│  ├─ espree@7.3.1
-│  │  ├─ URL: https://github.com/eslint/espree.git
-│  │  ├─ VendorName: Nicholas C. Zakas
-│  │  └─ VendorUrl: https://github.com/eslint/espree
-│  ├─ espree@9.4.1
-│  │  ├─ URL: https://github.com/eslint/espree.git
-│  │  ├─ VendorName: Nicholas C. Zakas
-│  │  └─ VendorUrl: https://github.com/eslint/espree
-│  ├─ esprima@4.0.1
-│  │  ├─ URL: https://github.com/jquery/esprima.git
-│  │  ├─ VendorName: Ariya Hidayat
-│  │  └─ VendorUrl: http://esprima.org/
-│  ├─ esrecurse@4.3.0
-│  │  ├─ URL: https://github.com/estools/esrecurse.git
-│  │  └─ VendorUrl: https://github.com/estools/esrecurse
-│  ├─ estraverse@4.3.0
-│  │  ├─ URL: http://github.com/estools/estraverse.git
-│  │  └─ VendorUrl: https://github.com/estools/estraverse
-│  ├─ estraverse@5.3.0
-│  │  ├─ URL: http://github.com/estools/estraverse.git
-│  │  └─ VendorUrl: https://github.com/estools/estraverse
-│  ├─ esutils@2.0.3
-│  │  ├─ URL: http://github.com/estools/esutils.git
-│  │  └─ VendorUrl: https://github.com/estools/esutils
-│  ├─ glob-to-regexp@0.4.1
-│  │  ├─ URL: https://github.com/fitzgen/glob-to-regexp.git
-│  │  └─ VendorName: Nick Fitzgerald
-│  ├─ nth-check@2.1.1
-│  │  ├─ URL: https://github.com/fb55/nth-check
-│  │  ├─ VendorName: Felix Boehm
-│  │  └─ VendorUrl: https://github.com/fb55/nth-check
-│  ├─ regjsparser@0.9.1
-│  │  ├─ URL: git@github.com:jviereck/regjsparser.git
-│  │  ├─ VendorName: 'Julian Viereck'
-│  │  └─ VendorUrl: https://github.com/jviereck/regjsparser
-│  ├─ stringify-object@3.3.0
-│  │  ├─ URL: https://github.com/yeoman/stringify-object.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ terser@5.16.3
-│  │  ├─ URL: https://github.com/terser/terser
-│  │  ├─ VendorName: Mihai Bazon
-│  │  └─ VendorUrl: https://terser.org/
-│  ├─ uri-js@4.4.1
-│  │  ├─ URL: http://github.com/garycourt/uri-js
-│  │  ├─ VendorName: Gary Court
-│  │  └─ VendorUrl: https://github.com/garycourt/uri-js
-│  ├─ webidl-conversions@4.0.2
-│  │  ├─ URL: https://github.com/jsdom/webidl-conversions.git
-│  │  ├─ VendorName: Domenic Denicola
-│  │  └─ VendorUrl: https://domenic.me/
-│  ├─ webidl-conversions@5.0.0
-│  │  ├─ URL: https://github.com/jsdom/webidl-conversions.git
-│  │  ├─ VendorName: Domenic Denicola
-│  │  └─ VendorUrl: https://domenic.me/
-│  └─ webidl-conversions@6.1.0
-│     ├─ URL: https://github.com/jsdom/webidl-conversions.git
-│     ├─ VendorName: Domenic Denicola
-│     └─ VendorUrl: https://domenic.me/
-├─ BSD-3-Clause
-│  ├─ @humanwhocodes/object-schema@1.2.1
-│  │  ├─ URL: git+https://github.com/humanwhocodes/object-schema.git
-│  │  ├─ VendorName: Nicholas C. Zakas
-│  │  └─ VendorUrl: https://github.com/humanwhocodes/object-schema#readme
-│  ├─ @sinonjs/commons@1.8.6
-│  │  ├─ URL: git+https://github.com/sinonjs/commons.git
-│  │  └─ VendorUrl: https://github.com/sinonjs/commons#readme
-│  ├─ @sinonjs/fake-timers@8.1.0
-│  │  ├─ URL: https://github.com/sinonjs/fake-timers.git
-│  │  ├─ VendorName: Christian Johansen
-│  │  └─ VendorUrl: https://github.com/sinonjs/fake-timers
-│  ├─ @xtuc/ieee754@1.2.0
-│  │  ├─ URL: git://github.com/feross/ieee754.git
-│  │  ├─ VendorName: Feross Aboukhadijeh
-│  │  └─ VendorUrl: http://feross.org
-│  ├─ abab@2.0.6
-│  │  ├─ URL: git+https://github.com/jsdom/abab.git
-│  │  ├─ VendorName: Jeff Carpenter
-│  │  └─ VendorUrl: https://github.com/jsdom/abab#readme
-│  ├─ babel-plugin-istanbul@6.1.1
-│  │  ├─ URL: git+https://github.com/istanbuljs/babel-plugin-istanbul.git
-│  │  ├─ VendorName: Thai Pangsakulyanont @dtinth
-│  │  └─ VendorUrl: https://github.com/istanbuljs/babel-plugin-istanbul#readme
-│  ├─ eslint-plugin-flowtype@8.0.3
-│  │  ├─ URL: https://github.com/gajus/eslint-plugin-flowtype
-│  │  ├─ VendorName: Gajus Kuizinas
-│  │  └─ VendorUrl: http://gajus.com
-│  ├─ esquery@1.4.0
-│  │  ├─ URL: https://github.com/estools/esquery.git
-│  │  ├─ VendorName: Joel Feenstra
-│  │  └─ VendorUrl: https://github.com/estools/esquery/
-│  ├─ filesize@8.0.7
-│  │  ├─ URL: git://github.com/avoidwork/filesize.js.git
-│  │  ├─ VendorName: Jason Mulligan
-│  │  └─ VendorUrl: https://filesizejs.com/
-│  ├─ hoist-non-react-statics@3.3.2
-│  │  ├─ URL: git://github.com/mridgway/hoist-non-react-statics.git
-│  │  └─ VendorName: Michael Ridgway
-│  ├─ istanbul-lib-coverage@3.2.0
-│  │  ├─ URL: git+ssh://git@github.com/istanbuljs/istanbuljs.git
-│  │  ├─ VendorName: Krishnan Anantheswaran
-│  │  └─ VendorUrl: https://istanbul.js.org/
-│  ├─ istanbul-lib-instrument@5.2.1
-│  │  ├─ URL: git+ssh://git@github.com/istanbuljs/istanbuljs.git
-│  │  ├─ VendorName: Krishnan Anantheswaran
-│  │  └─ VendorUrl: https://istanbul.js.org/
-│  ├─ istanbul-lib-report@3.0.0
-│  │  ├─ URL: git+ssh://git@github.com/istanbuljs/istanbuljs.git
-│  │  ├─ VendorName: Krishnan Anantheswaran
-│  │  └─ VendorUrl: https://istanbul.js.org/
-│  ├─ istanbul-lib-source-maps@4.0.1
-│  │  ├─ URL: git+ssh://git@github.com/istanbuljs/istanbuljs.git
-│  │  ├─ VendorName: Krishnan Anantheswaran
-│  │  └─ VendorUrl: https://istanbul.js.org/
-│  ├─ istanbul-reports@3.1.5
-│  │  ├─ URL: git+ssh://git@github.com/istanbuljs/istanbuljs.git
-│  │  ├─ VendorName: Krishnan Anantheswaran
-│  │  └─ VendorUrl: https://istanbul.js.org/
-│  ├─ makeerror@1.0.12
-│  │  ├─ URL: https://github.com/daaku/nodejs-makeerror
-│  │  └─ VendorName: Naitik Shah
-│  ├─ qs@6.11.0
-│  │  ├─ URL: https://github.com/ljharb/qs.git
-│  │  └─ VendorUrl: https://github.com/ljharb/qs
-│  ├─ react-transition-group@4.4.5
-│  │  ├─ URL: https://github.com/reactjs/react-transition-group.git
-│  │  └─ VendorUrl: https://github.com/reactjs/react-transition-group#readme
-│  ├─ serialize-javascript@4.0.0
-│  │  ├─ URL: git+https://github.com/yahoo/serialize-javascript.git
-│  │  ├─ VendorName: Eric Ferraiuolo
-│  │  └─ VendorUrl: https://github.com/yahoo/serialize-javascript
-│  ├─ serialize-javascript@6.0.1
-│  │  ├─ URL: git+https://github.com/yahoo/serialize-javascript.git
-│  │  ├─ VendorName: Eric Ferraiuolo
-│  │  └─ VendorUrl: https://github.com/yahoo/serialize-javascript
-│  ├─ source-map-js@1.0.2
-│  │  ├─ URL: https://github.com/7rulnik/source-map-js.git
-│  │  ├─ VendorName: Valentin 7rulnik Semirulnik
-│  │  └─ VendorUrl: https://github.com/7rulnik/source-map-js
-│  ├─ source-map@0.5.7
-│  │  ├─ URL: http://github.com/mozilla/source-map.git
-│  │  ├─ VendorName: Nick Fitzgerald
-│  │  └─ VendorUrl: https://github.com/mozilla/source-map
-│  ├─ source-map@0.6.1
-│  │  ├─ URL: http://github.com/mozilla/source-map.git
-│  │  ├─ VendorName: Nick Fitzgerald
-│  │  └─ VendorUrl: https://github.com/mozilla/source-map
-│  ├─ source-map@0.7.4
-│  │  ├─ URL: http://github.com/mozilla/source-map.git
-│  │  ├─ VendorName: Nick Fitzgerald
-│  │  └─ VendorUrl: https://github.com/mozilla/source-map
-│  ├─ source-map@0.8.0-beta.0
-│  │  ├─ URL: http://github.com/mozilla/source-map.git
-│  │  ├─ VendorName: Nick Fitzgerald
-│  │  └─ VendorUrl: https://github.com/mozilla/source-map
-│  ├─ sprintf-js@1.0.3
-│  │  ├─ URL: https://github.com/alexei/sprintf.js.git
-│  │  ├─ VendorName: Alexandru Marasteanu
-│  │  └─ VendorUrl: http://alexei.ro/
-│  ├─ table@6.8.1
-│  │  ├─ URL: https://github.com/gajus/table
-│  │  ├─ VendorName: Gajus Kuizinas
-│  │  └─ VendorUrl: http://gajus.com
-│  ├─ tmpl@1.0.5
-│  │  ├─ URL: https://github.com/daaku/nodejs-tmpl
-│  │  ├─ VendorName: Naitik Shah
-│  │  └─ VendorUrl: https://github.com/daaku/nodejs-tmpl
-│  └─ tough-cookie@4.1.2
-│     ├─ URL: git://github.com/salesforce/tough-cookie.git
-│     ├─ VendorName: Jeremy Stashewsky
-│     └─ VendorUrl: https://github.com/salesforce/tough-cookie
-├─ CC-BY-4.0
-│  └─ caniuse-lite@1.0.30001450
-│     ├─ URL: https://github.com/browserslist/caniuse-lite.git
-│     ├─ VendorName: Ben Briggs
-│     └─ VendorUrl: http://beneb.info
-├─ CC0-1.0
-│  ├─ @csstools/normalize.css@12.0.0
-│  │  ├─ URL: https://github.com/csstools/normalize.css.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/normalize.css#readme
-│  ├─ @csstools/postcss-cascade-layers@1.1.1
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-cascade-layers#readme
-│  ├─ @csstools/postcss-color-function@1.1.1
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-color-function#readme
-│  ├─ @csstools/postcss-font-format-keywords@1.0.1
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-font-format-keywords#readme
-│  ├─ @csstools/postcss-hwb-function@1.0.2
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-hwb-function#readme
-│  ├─ @csstools/postcss-ic-unit@1.0.1
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-ic-unit#readme
-│  ├─ @csstools/postcss-is-pseudo-class@2.0.7
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-is-pseudo-class#readme
-│  ├─ @csstools/postcss-nested-calc@1.0.0
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-nested-calc#readme
-│  ├─ @csstools/postcss-normalize-display-values@1.0.1
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  └─ VendorName: Jonathan Neal
-│  ├─ @csstools/postcss-oklab-function@1.1.1
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-oklab-function#readme
-│  ├─ @csstools/postcss-progressive-custom-properties@1.3.0
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  └─ VendorName: Jonathan Neal
-│  ├─ @csstools/postcss-stepped-value-functions@1.0.1
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-stepped-value-functions#readme
-│  ├─ @csstools/postcss-text-decoration-shorthand@1.0.0
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-text-decoration-shorthand#readme
-│  ├─ @csstools/postcss-trigonometric-functions@1.0.2
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-trigonometric-functions#readme
-│  ├─ @csstools/postcss-unset-value@1.0.2
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-unset-value#readme
-│  ├─ @csstools/selector-specificity@2.1.1
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/packages/selector-specificity#readme
-│  ├─ css-blank-pseudo@3.0.3
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/css-blank-pseudo#readme
-│  ├─ css-has-pseudo@3.0.4
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/css-has-pseudo#readme
-│  ├─ css-prefers-color-scheme@6.0.3
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/css-prefers-color-scheme#readme
-│  ├─ cssdb@7.4.1
-│  │  ├─ URL: https://github.com/csstools/cssdb.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/cssdb#readme
-│  ├─ language-subtag-registry@0.3.22
-│  │  ├─ URL: https://github.com/mattcg/language-subtag-registry
-│  │  └─ VendorUrl: https://github.com/mattcg/language-subtag-registry
-│  ├─ mdn-data@2.0.14
-│  │  ├─ URL: https://github.com/mdn/data.git
-│  │  ├─ VendorName: Mozilla Developer Network
-│  │  └─ VendorUrl: https://developer.mozilla.org/
-│  ├─ mdn-data@2.0.4
-│  │  ├─ URL: https://github.com/mdn/data.git
-│  │  ├─ VendorName: Mozilla Developer Network
-│  │  └─ VendorUrl: https://developer.mozilla.org/
-│  ├─ postcss-browser-comments@4.0.0
-│  │  ├─ URL: https://github.com/csstools/postcss-browser-comments.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-browser-comments#readme
-│  ├─ postcss-color-functional-notation@4.2.4
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-color-functional-notation#readme
-│  ├─ postcss-color-rebeccapurple@7.1.1
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-color-rebeccapurple#readme
-│  ├─ postcss-dir-pseudo-class@6.0.5
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-dir-pseudo-class#readme
-│  ├─ postcss-double-position-gradients@3.1.2
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-double-position-gradients#readme
-│  ├─ postcss-env-function@4.0.6
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-env-function#readme
-│  ├─ postcss-focus-visible@6.0.4
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-focus-visible#readme
-│  ├─ postcss-focus-within@5.0.4
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-focus-within#readme
-│  ├─ postcss-gap-properties@3.0.5
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-gap-properties#readme
-│  ├─ postcss-image-set-function@4.0.7
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-image-set-function#readme
-│  ├─ postcss-lab-function@4.2.1
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-lab-function#readme
-│  ├─ postcss-logical@5.0.4
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-logical#readme
-│  ├─ postcss-nesting@10.2.0
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-nesting#readme
-│  ├─ postcss-normalize@10.0.1
-│  │  ├─ URL: https://github.com/csstools/postcss-normalize.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-normalize#readme
-│  ├─ postcss-overflow-shorthand@3.0.4
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-overflow-shorthand#readme
-│  ├─ postcss-place@7.0.5
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-place#readme
-│  ├─ postcss-preset-env@7.8.3
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugin-packs/postcss-preset-env#readme
-│  ├─ postcss-pseudo-class-any-link@7.1.6
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-pseudo-class-any-link#readme
-│  └─ sanitize.css@13.0.0
-│     ├─ URL: https://github.com/csstools/sanitize.css.git
-│     ├─ VendorName: Jonathan Neal
-│     └─ VendorUrl: https://github.com/csstools/sanitize.css#readme
-├─ ISC
-│  ├─ @istanbuljs/load-nyc-config@1.1.0
-│  │  ├─ URL: git+https://github.com/istanbuljs/load-nyc-config.git
-│  │  └─ VendorUrl: https://github.com/istanbuljs/load-nyc-config#readme
-│  ├─ @trysound/sax@0.2.0
-│  │  ├─ URL: git://github.com/svg/sax.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ anymatch@3.1.3
-│  │  ├─ URL: https://github.com/micromatch/anymatch
-│  │  ├─ VendorName: Elan Shanker
-│  │  └─ VendorUrl: https://github.com/micromatch/anymatch
-│  ├─ ast-types-flow@0.0.7
-│  │  ├─ URL: git+https://github.com/kyldvs/ast-types-flow.git
-│  │  ├─ VendorName: kyldvs
-│  │  └─ VendorUrl: https://github.com/kyldvs/ast-types-flow#readme
-│  ├─ at-least-node@1.0.0
-│  │  ├─ URL: git+https://github.com/RyanZim/at-least-node.git
-│  │  ├─ VendorName: Ryan Zimmerman
-│  │  └─ VendorUrl: https://github.com/RyanZim/at-least-node#readme
-│  ├─ boolbase@1.0.0
-│  │  ├─ URL: https://github.com/fb55/boolbase
-│  │  ├─ VendorName: Felix Boehm
-│  │  └─ VendorUrl: https://github.com/fb55/boolbase
-│  ├─ cliui@7.0.4
-│  │  ├─ URL: https://github.com/yargs/cliui.git
-│  │  └─ VendorName: Ben Coe
-│  ├─ common-path-prefix@3.0.0
-│  │  ├─ URL: git+https://github.com/novemberborn/common-path-prefix.git
-│  │  ├─ VendorName: Mark Wubben
-│  │  └─ VendorUrl: https://github.com/novemberborn/common-path-prefix#readme
-│  ├─ css-color-keywords@1.0.0
-│  │  ├─ URL: https://github.com/sonicdoe/css-color-keywords.git
-│  │  └─ VendorName: Jakob Krigovsky
-│  ├─ css-declaration-sorter@6.3.1
-│  │  ├─ URL: https://github.com/Siilwyn/css-declaration-sorter.git
-│  │  ├─ VendorName: Selwyn
-│  │  └─ VendorUrl: https://selwyn.cc/
-│  ├─ electron-to-chromium@1.4.288
-│  │  ├─ URL: https://github.com/kilian/electron-to-chromium/
-│  │  └─ VendorName: Kilian Valkhof
-│  ├─ fastq@1.15.0
-│  │  ├─ URL: git+https://github.com/mcollina/fastq.git
-│  │  ├─ VendorName: Matteo Collina
-│  │  └─ VendorUrl: https://github.com/mcollina/fastq#readme
-│  ├─ flatted@3.2.7
-│  │  ├─ URL: git+https://github.com/WebReflection/flatted.git
-│  │  ├─ VendorName: Andrea Giammarchi
-│  │  └─ VendorUrl: https://github.com/WebReflection/flatted#readme
-│  ├─ fs.realpath@1.0.0
-│  │  ├─ URL: git+https://github.com/isaacs/fs.realpath.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ get-caller-file@2.0.5
-│  │  ├─ URL: git+https://github.com/stefanpenner/get-caller-file.git
-│  │  ├─ VendorName: Stefan Penner
-│  │  └─ VendorUrl: https://github.com/stefanpenner/get-caller-file#readme
-│  ├─ get-own-enumerable-property-symbols@3.0.2
-│  │  ├─ URL: git+https://github.com/mightyiam/get-own-enumerable-property-symbols.git
-│  │  ├─ VendorName: Shahar Or
-│  │  └─ VendorUrl: https://github.com/mightyiam/get-own-enumerable-property-symbols#readme
-│  ├─ glob-parent@5.1.2
-│  │  ├─ URL: https://github.com/gulpjs/glob-parent.git
-│  │  ├─ VendorName: Gulp Team
-│  │  └─ VendorUrl: https://gulpjs.com/
-│  ├─ glob-parent@6.0.2
-│  │  ├─ URL: https://github.com/gulpjs/glob-parent.git
-│  │  ├─ VendorName: Gulp Team
-│  │  └─ VendorUrl: https://gulpjs.com/
-│  ├─ glob@7.2.3
-│  │  ├─ URL: git://github.com/isaacs/node-glob.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ graceful-fs@4.2.10
-│  │  └─ URL: https://github.com/isaacs/node-graceful-fs
-│  ├─ icss-utils@5.1.0
-│  │  ├─ URL: git+https://github.com/css-modules/icss-utils.git
-│  │  ├─ VendorName: Glen Maddern
-│  │  └─ VendorUrl: https://github.com/css-modules/icss-utils#readme
-│  ├─ idb@7.1.1
-│  │  ├─ URL: git://github.com/jakearchibald/idb.git
-│  │  └─ VendorName: Jake Archibald
-│  ├─ inflight@1.0.6
-│  │  ├─ URL: https://github.com/npm/inflight.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: https://github.com/isaacs/inflight
-│  ├─ inherits@2.0.3
-│  │  └─ URL: git://github.com/isaacs/inherits
-│  ├─ inherits@2.0.4
-│  │  └─ URL: git://github.com/isaacs/inherits
-│  ├─ ini@1.3.8
-│  │  ├─ URL: git://github.com/isaacs/ini.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ isexe@2.0.0
-│  │  ├─ URL: git+https://github.com/isaacs/isexe.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: https://github.com/isaacs/isexe#readme
-│  ├─ lru-cache@5.1.1
-│  │  ├─ URL: git://github.com/isaacs/node-lru-cache.git
-│  │  └─ VendorName: Isaac Z. Schlueter
-│  ├─ lru-cache@6.0.0
-│  │  ├─ URL: git://github.com/isaacs/node-lru-cache.git
-│  │  └─ VendorName: Isaac Z. Schlueter
-│  ├─ minimalistic-assert@1.0.1
-│  │  ├─ URL: https://github.com/calvinmetcalf/minimalistic-assert.git
-│  │  └─ VendorUrl: https://github.com/calvinmetcalf/minimalistic-assert
-│  ├─ minimatch@3.1.2
-│  │  ├─ URL: git://github.com/isaacs/minimatch.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me
-│  ├─ minimatch@5.1.6
-│  │  ├─ URL: git://github.com/isaacs/minimatch.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me
-│  ├─ once@1.4.0
-│  │  ├─ URL: git://github.com/isaacs/once
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ picocolors@0.2.1
-│  │  ├─ URL: https://github.com/alexeyraspopov/picocolors.git
-│  │  └─ VendorName: Alexey Raspopov
-│  ├─ picocolors@1.0.0
-│  │  ├─ URL: https://github.com/alexeyraspopov/picocolors.git
-│  │  └─ VendorName: Alexey Raspopov
-│  ├─ postcss-modules-extract-imports@3.0.0
-│  │  ├─ URL: https://github.com/css-modules/postcss-modules-extract-imports.git
-│  │  ├─ VendorName: Glen Maddern
-│  │  └─ VendorUrl: https://github.com/css-modules/postcss-modules-extract-imports
-│  ├─ postcss-modules-scope@3.0.0
-│  │  ├─ URL: https://github.com/css-modules/postcss-modules-scope.git
-│  │  ├─ VendorName: Glen Maddern
-│  │  └─ VendorUrl: https://github.com/css-modules/postcss-modules-scope
-│  ├─ postcss-modules-values@4.0.0
-│  │  ├─ URL: git+https://github.com/css-modules/postcss-modules-values.git
-│  │  ├─ VendorName: Glen Maddern
-│  │  └─ VendorUrl: https://github.com/css-modules/postcss-modules-values#readme
-│  ├─ rimraf@3.0.2
-│  │  ├─ URL: git://github.com/isaacs/rimraf.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ sax@1.2.4
-│  │  ├─ URL: git://github.com/isaacs/sax-js.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ saxes@5.0.1
-│  │  ├─ URL: https://github.com/lddubeau/saxes.git
-│  │  └─ VendorName: Louis-Dominique Dubeau
-│  ├─ semver@6.3.0
-│  │  └─ URL: https://github.com/npm/node-semver
-│  ├─ semver@7.3.8
-│  │  ├─ URL: https://github.com/npm/node-semver.git
-│  │  └─ VendorName: GitHub Inc.
-│  ├─ setprototypeof@1.1.0
-│  │  ├─ URL: https://github.com/wesleytodd/setprototypeof.git
-│  │  ├─ VendorName: Wes Todd
-│  │  └─ VendorUrl: https://github.com/wesleytodd/setprototypeof
-│  ├─ setprototypeof@1.2.0
-│  │  ├─ URL: https://github.com/wesleytodd/setprototypeof.git
-│  │  ├─ VendorName: Wes Todd
-│  │  └─ VendorUrl: https://github.com/wesleytodd/setprototypeof
-│  ├─ signal-exit@3.0.7
-│  │  ├─ URL: https://github.com/tapjs/signal-exit.git
-│  │  ├─ VendorName: Ben Coe
-│  │  └─ VendorUrl: https://github.com/tapjs/signal-exit
-│  ├─ test-exclude@6.0.0
-│  │  ├─ URL: git+https://github.com/istanbuljs/test-exclude.git
-│  │  ├─ VendorName: Ben Coe
-│  │  └─ VendorUrl: https://istanbul.js.org/
-│  ├─ v8-to-istanbul@8.1.1
-│  │  ├─ URL: https://github.com/istanbuljs/v8-to-istanbul.git
-│  │  └─ VendorName: Ben Coe
-│  ├─ which@1.3.1
-│  │  ├─ URL: git://github.com/isaacs/node-which.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me
-│  ├─ which@2.0.2
-│  │  ├─ URL: git://github.com/isaacs/node-which.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me
-│  ├─ wrappy@1.0.2
-│  │  ├─ URL: https://github.com/npm/wrappy
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: https://github.com/npm/wrappy
-│  ├─ write-file-atomic@3.0.3
-│  │  ├─ URL: git://github.com/npm/write-file-atomic.git
-│  │  ├─ VendorName: Rebecca Turner
-│  │  └─ VendorUrl: https://github.com/npm/write-file-atomic
-│  ├─ y18n@5.0.8
-│  │  ├─ URL: https://github.com/yargs/y18n.git
-│  │  ├─ VendorName: Ben Coe
-│  │  └─ VendorUrl: https://github.com/yargs/y18n
-│  ├─ yallist@3.1.1
-│  │  ├─ URL: git+https://github.com/isaacs/yallist.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ yallist@4.0.0
-│  │  ├─ URL: git+https://github.com/isaacs/yallist.git
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ yaml@1.10.2
-│  │  ├─ URL: https://github.com/eemeli/yaml.git
-│  │  ├─ VendorName: Eemeli Aro
-│  │  └─ VendorUrl: https://eemeli.org/yaml/v1/
-│  └─ yargs-parser@20.2.9
-│     ├─ URL: https://github.com/yargs/yargs-parser.git
-│     └─ VendorName: Ben Coe
-├─ MIT
-│  ├─ @adobe/css-tools@4.1.0
-│  │  ├─ URL: https://github.com/adobe/css-tools.git
-│  │  └─ VendorName: TJ Holowaychuk
-│  ├─ @apideck/better-ajv-errors@0.3.6
-│  │  ├─ URL: https://github.com/apideck-libraries/better-ajv-errors
-│  │  ├─ VendorName: Apideck
-│  │  └─ VendorUrl: https://apideck.com/
-│  ├─ @babel/code-frame@7.12.11
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: Sebastian McKenzie
-│  │  └─ VendorUrl: https://babeljs.io/
-│  ├─ @babel/code-frame@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-code-frame
-│  ├─ @babel/compat-data@7.20.14
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/team
-│  ├─ @babel/core@7.20.12
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-core
-│  ├─ @babel/eslint-parser@7.19.1
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/
-│  ├─ @babel/generator@7.20.14
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-generator
-│  ├─ @babel/helper-annotate-as-pure@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-annotate-as-pure
-│  ├─ @babel/helper-builder-binary-assignment-operator-visitor@7.18.9
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-builder-binary-assignment-operator-visitor
-│  ├─ @babel/helper-compilation-targets@7.20.7
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/team
-│  ├─ @babel/helper-create-class-features-plugin@7.20.12
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/team
-│  ├─ @babel/helper-create-regexp-features-plugin@7.20.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/team
-│  ├─ @babel/helper-define-polyfill-provider@0.3.3
-│  │  └─ URL: https://github.com/babel/babel-polyfills.git
-│  ├─ @babel/helper-environment-visitor@7.18.9
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-environment-visitor
-│  ├─ @babel/helper-explode-assignable-expression@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-explode-assignable-expression
-│  ├─ @babel/helper-function-name@7.19.0
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-function-name
-│  ├─ @babel/helper-hoist-variables@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-hoist-variables
-│  ├─ @babel/helper-member-expression-to-functions@7.20.7
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-member-expression-to-functions
-│  ├─ @babel/helper-module-imports@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-module-imports
-│  ├─ @babel/helper-module-transforms@7.20.11
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-module-transforms
-│  ├─ @babel/helper-optimise-call-expression@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-optimise-call-expression
-│  ├─ @babel/helper-plugin-utils@7.20.2
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-plugin-utils
-│  ├─ @babel/helper-remap-async-to-generator@7.18.9
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-remap-async-to-generator
-│  ├─ @babel/helper-replace-supers@7.20.7
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-replace-supers
-│  ├─ @babel/helper-simple-access@7.20.2
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-simple-access
-│  ├─ @babel/helper-skip-transparent-expression-wrappers@7.20.0
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/team
-│  ├─ @babel/helper-split-export-declaration@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-split-export-declaration
-│  ├─ @babel/helper-string-parser@7.19.4
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-string-parser
-│  ├─ @babel/helper-validator-identifier@7.19.1
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/team
-│  ├─ @babel/helper-validator-option@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/team
-│  ├─ @babel/helper-wrap-function@7.20.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helper-wrap-function
-│  ├─ @babel/helpers@7.20.13
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-helpers
-│  ├─ @babel/highlight@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-highlight
-│  ├─ @babel/parser@7.20.15
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-parser
-│  ├─ @babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-bugfix-safari-id-destructuring-collision-in-function-expression
-│  ├─ @babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.20.7
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-bugfix-v8-spread-parameters-in-optional-chaining
-│  ├─ @babel/plugin-proposal-async-generator-functions@7.20.7
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-async-generator-functions
-│  ├─ @babel/plugin-proposal-class-properties@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-class-properties
-│  ├─ @babel/plugin-proposal-class-static-block@7.20.7
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-class-static-block
-│  ├─ @babel/plugin-proposal-decorators@7.20.13
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-decorators
-│  ├─ @babel/plugin-proposal-dynamic-import@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/team
-│  ├─ @babel/plugin-proposal-export-namespace-from@7.18.9
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-export-namespace-from
-│  ├─ @babel/plugin-proposal-json-strings@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-json-strings
-│  ├─ @babel/plugin-proposal-logical-assignment-operators@7.20.7
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-logical-assignment-operators
-│  ├─ @babel/plugin-proposal-nullish-coalescing-operator@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-nullish-coalescing-operator
-│  ├─ @babel/plugin-proposal-numeric-separator@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-numeric-separator
-│  ├─ @babel/plugin-proposal-object-rest-spread@7.20.7
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-object-rest-spread
-│  ├─ @babel/plugin-proposal-optional-catch-binding@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-optional-catch-binding
-│  ├─ @babel/plugin-proposal-optional-chaining@7.20.7
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-optional-chaining
-│  ├─ @babel/plugin-proposal-private-methods@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-private-methods
-│  ├─ @babel/plugin-proposal-private-property-in-object@7.20.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-private-property-in-object
-│  ├─ @babel/plugin-proposal-unicode-property-regex@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-proposal-unicode-property-regex
-│  ├─ @babel/plugin-syntax-async-generators@7.8.4
-│  │  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-async-generators
-│  ├─ @babel/plugin-syntax-bigint@7.8.3
-│  │  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-bigint
-│  ├─ @babel/plugin-syntax-class-properties@7.12.13
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-syntax-class-properties
-│  ├─ @babel/plugin-syntax-class-static-block@7.14.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-syntax-class-static-block
-│  ├─ @babel/plugin-syntax-decorators@7.19.0
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-syntax-decorators
-│  ├─ @babel/plugin-syntax-dynamic-import@7.8.3
-│  │  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-dynamic-import
-│  ├─ @babel/plugin-syntax-export-namespace-from@7.8.3
-│  │  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-export-namespace-from
-│  ├─ @babel/plugin-syntax-flow@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-syntax-flow
-│  ├─ @babel/plugin-syntax-import-assertions@7.20.0
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/team
-│  ├─ @babel/plugin-syntax-import-meta@7.10.4
-│  │  └─ URL: https://github.com/babel/babel.git
-│  ├─ @babel/plugin-syntax-json-strings@7.8.3
-│  │  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-json-strings
-│  ├─ @babel/plugin-syntax-jsx@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-syntax-jsx
-│  ├─ @babel/plugin-syntax-logical-assignment-operators@7.10.4
-│  │  └─ URL: https://github.com/babel/babel.git
-│  ├─ @babel/plugin-syntax-nullish-coalescing-operator@7.8.3
-│  │  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-nullish-coalescing-operator
-│  ├─ @babel/plugin-syntax-numeric-separator@7.10.4
-│  │  └─ URL: https://github.com/babel/babel.git
-│  ├─ @babel/plugin-syntax-object-rest-spread@7.8.3
-│  │  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-object-rest-spread
-│  ├─ @babel/plugin-syntax-optional-catch-binding@7.8.3
-│  │  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-catch-binding
-│  ├─ @babel/plugin-syntax-optional-chaining@7.8.3
-│  │  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-chaining
-│  ├─ @babel/plugin-syntax-private-property-in-object@7.14.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-syntax-private-property-in-object
-│  ├─ @babel/plugin-syntax-top-level-await@7.14.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-syntax-top-level-await
-│  ├─ @babel/plugin-syntax-typescript@7.20.0
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-syntax-typescript
-│  ├─ @babel/plugin-transform-arrow-functions@7.20.7
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-arrow-functions
-│  ├─ @babel/plugin-transform-async-to-generator@7.20.7
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-async-to-generator
-│  ├─ @babel/plugin-transform-block-scoped-functions@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-block-scoped-functions
-│  ├─ @babel/plugin-transform-block-scoping@7.20.15
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-block-scoping
-│  ├─ @babel/plugin-transform-classes@7.20.7
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-classes
-│  ├─ @babel/plugin-transform-computed-properties@7.20.7
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-computed-properties
-│  ├─ @babel/plugin-transform-destructuring@7.20.7
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-destructuring
-│  ├─ @babel/plugin-transform-dotall-regex@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-dotall-regex
-│  ├─ @babel/plugin-transform-duplicate-keys@7.18.9
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-duplicate-keys
-│  ├─ @babel/plugin-transform-exponentiation-operator@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-exponentiation-operator
-│  ├─ @babel/plugin-transform-flow-strip-types@7.19.0
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-flow-strip-types
-│  ├─ @babel/plugin-transform-for-of@7.18.8
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-for-of
-│  ├─ @babel/plugin-transform-function-name@7.18.9
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-function-name
-│  ├─ @babel/plugin-transform-literals@7.18.9
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-literals
-│  ├─ @babel/plugin-transform-member-expression-literals@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-member-expression-literals
-│  ├─ @babel/plugin-transform-modules-amd@7.20.11
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-modules-amd
-│  ├─ @babel/plugin-transform-modules-commonjs@7.20.11
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-modules-commonjs
-│  ├─ @babel/plugin-transform-modules-systemjs@7.20.11
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-modules-systemjs
-│  ├─ @babel/plugin-transform-modules-umd@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-modules-umd
-│  ├─ @babel/plugin-transform-named-capturing-groups-regex@7.20.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-named-capturing-groups-regex
-│  ├─ @babel/plugin-transform-new-target@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-new-target
-│  ├─ @babel/plugin-transform-object-super@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-object-super
-│  ├─ @babel/plugin-transform-parameters@7.20.7
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-parameters
-│  ├─ @babel/plugin-transform-property-literals@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-property-literals
-│  ├─ @babel/plugin-transform-react-constant-elements@7.20.2
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-react-constant-elements
-│  ├─ @babel/plugin-transform-react-display-name@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-react-display-name
-│  ├─ @babel/plugin-transform-react-jsx-development@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/team
-│  ├─ @babel/plugin-transform-react-jsx@7.20.13
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-react-jsx
-│  ├─ @babel/plugin-transform-react-pure-annotations@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/team
-│  ├─ @babel/plugin-transform-regenerator@7.20.5
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-regenerator
-│  ├─ @babel/plugin-transform-reserved-words@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-reserved-words
-│  ├─ @babel/plugin-transform-runtime@7.19.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-runtime
-│  ├─ @babel/plugin-transform-shorthand-properties@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-shorthand-properties
-│  ├─ @babel/plugin-transform-spread@7.20.7
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-spread
-│  ├─ @babel/plugin-transform-sticky-regex@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-sticky-regex
-│  ├─ @babel/plugin-transform-template-literals@7.18.9
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-template-literals
-│  ├─ @babel/plugin-transform-typeof-symbol@7.18.9
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-typeof-symbol
-│  ├─ @babel/plugin-transform-typescript@7.20.13
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-typescript
-│  ├─ @babel/plugin-transform-unicode-escapes@7.18.10
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-unicode-escapes
-│  ├─ @babel/plugin-transform-unicode-regex@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-plugin-transform-unicode-regex
-│  ├─ @babel/preset-env@7.20.2
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-preset-env
-│  ├─ @babel/preset-modules@0.1.5
-│  │  └─ URL: https://github.com/babel/preset-modules.git
-│  ├─ @babel/preset-react@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-preset-react
-│  ├─ @babel/preset-typescript@7.18.6
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-preset-typescript
-│  ├─ @babel/runtime@7.20.13
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-runtime
-│  ├─ @babel/runtime@7.21.0
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-runtime
-│  ├─ @babel/template@7.20.7
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-template
-│  ├─ @babel/traverse@7.20.13
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-traverse
-│  ├─ @babel/types@7.20.7
-│  │  ├─ URL: https://github.com/babel/babel.git
-│  │  ├─ VendorName: The Babel Team
-│  │  └─ VendorUrl: https://babel.dev/docs/en/next/babel-types
-│  ├─ @bcoe/v8-coverage@0.2.3
-│  │  ├─ URL: git://github.com/demurgos/v8-coverage.git
-│  │  ├─ VendorName: Charles Samborski
-│  │  └─ VendorUrl: https://demurgos.github.io/v8-coverage
-│  ├─ @emotion/babel-plugin@11.10.6
-│  │  ├─ URL: https://github.com/emotion-js/emotion/tree/main/packages/babel-plugin
-│  │  ├─ VendorName: Kye Hohenberger
-│  │  └─ VendorUrl: https://emotion.sh/
-│  ├─ @emotion/cache@11.10.5
-│  │  └─ URL: https://github.com/emotion-js/emotion/tree/main/packages/cache
-│  ├─ @emotion/hash@0.9.0
-│  │  └─ URL: https://github.com/emotion-js/emotion/tree/main/packages/hash
-│  ├─ @emotion/is-prop-valid@1.2.0
-│  │  └─ URL: https://github.com/emotion-js/emotion/tree/main/packages/is-prop-valid
-│  ├─ @emotion/memoize@0.8.0
-│  │  └─ URL: https://github.com/emotion-js/emotion/tree/main/packages/memoize
-│  ├─ @emotion/react@11.10.6
-│  │  ├─ URL: https://github.com/emotion-js/emotion/tree/main/packages/react
-│  │  └─ VendorName: Emotion Contributors
-│  ├─ @emotion/serialize@1.1.1
-│  │  └─ URL: https://github.com/emotion-js/emotion/tree/main/packages/serialize
-│  ├─ @emotion/sheet@1.2.1
-│  │  └─ URL: https://github.com/emotion-js/emotion/tree/main/packages/sheet
-│  ├─ @emotion/styled@11.10.6
-│  │  └─ URL: https://github.com/emotion-js/emotion/tree/main/packages/styled
-│  ├─ @emotion/stylis@0.8.5
-│  │  └─ URL: https://github.com/emotion-js/emotion/tree/master/packages/stylis
-│  ├─ @emotion/unitless@0.7.5
-│  │  └─ URL: https://github.com/emotion-js/emotion/tree/master/packages/unitless
-│  ├─ @emotion/unitless@0.8.0
-│  │  └─ URL: https://github.com/emotion-js/emotion/tree/main/packages/unitless
-│  ├─ @emotion/use-insertion-effect-with-fallbacks@1.0.0
-│  │  └─ URL: https://github.com/emotion-js/emotion/tree/main/packages/use-insertion-effect-with-fallbacks
-│  ├─ @emotion/utils@1.2.0
-│  │  └─ URL: https://github.com/emotion-js/emotion/tree/main/packages/utils
-│  ├─ @emotion/weak-memoize@0.3.0
-│  │  └─ URL: https://github.com/emotion-js/emotion/tree/main/packages/weak-memoize
-│  ├─ @eslint/eslintrc@0.4.3
-│  │  ├─ URL: https://github.com/eslint/eslintrc.git
-│  │  ├─ VendorName: Nicholas C. Zakas
-│  │  └─ VendorUrl: https://github.com/eslint/eslintrc#readme
-│  ├─ @eslint/eslintrc@1.4.1
-│  │  ├─ URL: https://github.com/eslint/eslintrc.git
-│  │  ├─ VendorName: Nicholas C. Zakas
-│  │  └─ VendorUrl: https://github.com/eslint/eslintrc#readme
-│  ├─ @istanbuljs/schema@0.1.3
-│  │  ├─ URL: git+https://github.com/istanbuljs/schema.git
-│  │  ├─ VendorName: Corey Farrell
-│  │  └─ VendorUrl: https://github.com/istanbuljs/schema#readme
-│  ├─ @jest/console@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/console@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/core@27.5.1
-│  │  ├─ URL: https://github.com/facebook/jest
-│  │  └─ VendorUrl: https://jestjs.io/
-│  ├─ @jest/environment@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/expect-utils@29.4.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/fake-timers@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/globals@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/reporters@27.5.1
-│  │  ├─ URL: https://github.com/facebook/jest
-│  │  └─ VendorUrl: https://jestjs.io/
-│  ├─ @jest/schemas@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/schemas@29.4.0
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/source-map@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/test-result@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/test-result@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/test-sequencer@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/transform@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/types@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/types@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jest/types@29.4.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ @jridgewell/gen-mapping@0.1.1
-│  │  ├─ URL: https://github.com/jridgewell/gen-mapping
-│  │  └─ VendorName: Justin Ridgewell
-│  ├─ @jridgewell/gen-mapping@0.3.2
-│  │  ├─ URL: https://github.com/jridgewell/gen-mapping
-│  │  └─ VendorName: Justin Ridgewell
-│  ├─ @jridgewell/resolve-uri@3.1.0
-│  │  ├─ URL: https://github.com/jridgewell/resolve-uri
-│  │  └─ VendorName: Justin Ridgewell
-│  ├─ @jridgewell/set-array@1.1.2
-│  │  ├─ URL: https://github.com/jridgewell/set-array
-│  │  └─ VendorName: Justin Ridgewell
-│  ├─ @jridgewell/source-map@0.3.2
-│  │  ├─ URL: https://github.com/jridgewell/source-map
-│  │  └─ VendorName: Justin Ridgewell
-│  ├─ @jridgewell/sourcemap-codec@1.4.14
-│  │  ├─ URL: git+https://github.com/jridgewell/sourcemap-codec.git
-│  │  └─ VendorName: Rich Harris
-│  ├─ @jridgewell/trace-mapping@0.3.17
-│  │  ├─ URL: git+https://github.com/jridgewell/trace-mapping.git
-│  │  └─ VendorName: Justin Ridgewell
-│  ├─ @leichtgewicht/ip-codec@2.0.4
-│  │  ├─ URL: git+https://github.com/martinheidegger/ip-codec.git
-│  │  ├─ VendorName: Martin Heidegger
-│  │  └─ VendorUrl: https://github.com/martinheidegger/ip-codec#readme
-│  ├─ @mui/base@5.0.0-alpha.118
-│  │  ├─ URL: https://github.com/mui/material-ui.git
-│  │  ├─ VendorName: MUI Team
-│  │  └─ VendorUrl: https://mui.com/base/getting-started/overview/
-│  ├─ @mui/core-downloads-tracker@5.11.9
-│  │  ├─ URL: https://github.com/mui/material-ui.git
-│  │  ├─ VendorName: MUI Team
-│  │  └─ VendorUrl: https://mui.com/
-│  ├─ @mui/material@5.11.10
-│  │  ├─ URL: https://github.com/mui/material-ui.git
-│  │  ├─ VendorName: MUI Team
-│  │  └─ VendorUrl: https://mui.com/material-ui/getting-started/overview/
-│  ├─ @mui/private-theming@5.11.9
-│  │  ├─ URL: https://github.com/mui/material-ui.git
-│  │  ├─ VendorName: MUI Team
-│  │  └─ VendorUrl: https://mui.com/
-│  ├─ @mui/styled-engine@5.11.9
-│  │  ├─ URL: https://github.com/mui/material-ui.git
-│  │  ├─ VendorName: MUI Team
-│  │  └─ VendorUrl: https://mui.com/material-ui/guides/styled-engine/
-│  ├─ @mui/system@5.11.9
-│  │  ├─ URL: https://github.com/mui/material-ui.git
-│  │  ├─ VendorName: MUI Team
-│  │  └─ VendorUrl: https://mui.com/system/getting-started/overview/
-│  ├─ @mui/types@7.2.3
-│  │  ├─ URL: https://github.com/mui/material-ui.git
-│  │  ├─ VendorName: MUI Team
-│  │  └─ VendorUrl: https://github.com/mui/material-ui/tree/master/packages/mui-types
-│  ├─ @mui/utils@5.11.9
-│  │  ├─ URL: https://github.com/mui/material-ui.git
-│  │  ├─ VendorName: MUI Team
-│  │  └─ VendorUrl: https://github.com/mui/material-ui/tree/master/packages/mui-utils
-│  ├─ @nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1
-│  ├─ @nodelib/fs.scandir@2.1.5
-│  │  └─ URL: https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.scandir
-│  ├─ @nodelib/fs.stat@2.0.5
-│  │  └─ URL: https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.stat
-│  ├─ @nodelib/fs.walk@1.2.8
-│  │  └─ URL: https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.walk
-│  ├─ @pmmmwh/react-refresh-webpack-plugin@0.5.10
-│  │  ├─ URL: git+https://github.com/pmmmwh/react-refresh-webpack-plugin.git
-│  │  ├─ VendorName: Michael Mok
-│  │  └─ VendorUrl: https://github.com/pmmmwh/react-refresh-webpack-plugin#readme
-│  ├─ @popperjs/core@2.11.6
-│  │  ├─ URL: https://github.com/popperjs/popper-core.git
-│  │  └─ VendorName: Federico Zivolo
-│  ├─ @reduxjs/toolkit@1.9.2
-│  │  ├─ URL: git+https://github.com/reduxjs/redux-toolkit.git
-│  │  ├─ VendorName: Mark Erikson
-│  │  └─ VendorUrl: https://redux-toolkit.js.org/
-│  ├─ @restart/hooks@0.4.8
-│  │  ├─ URL: git+https://github.com/jquense/react-common-hooks.git
-│  │  ├─ VendorName: Jason Quense
-│  │  └─ VendorUrl: https://github.com/react-restart/hooks#readme
-│  ├─ @restart/ui@1.5.4
-│  │  ├─ URL: git+https://github.com/react-restart/ui.git
-│  │  └─ VendorName: Jason Quense
-│  ├─ @rollup/plugin-babel@5.3.1
-│  │  ├─ URL: https://github.com/rollup/plugins.git
-│  │  ├─ VendorName: Rich Harris
-│  │  └─ VendorUrl: https://github.com/rollup/plugins/tree/master/packages/babel#readme
-│  ├─ @rollup/plugin-node-resolve@11.2.1
-│  │  ├─ URL: https://github.com/rollup/plugins.git
-│  │  ├─ VendorName: Rich Harris
-│  │  └─ VendorUrl: https://github.com/rollup/plugins/tree/master/packages/node-resolve/#readme
-│  ├─ @rollup/plugin-replace@2.4.2
-│  │  ├─ URL: https://github.com/rollup/plugins.git
-│  │  ├─ VendorName: Rich Harris
-│  │  └─ VendorUrl: https://github.com/rollup/plugins/tree/master/packages/replace#readme
-│  ├─ @rollup/pluginutils@3.1.0
-│  │  ├─ URL: https://github.com/rollup/plugins.git
-│  │  ├─ VendorName: Rich Harris
-│  │  └─ VendorUrl: https://github.com/rollup/plugins/tree/master/packages/pluginutils#readme
-│  ├─ @rushstack/eslint-patch@1.2.0
-│  │  ├─ URL: https://github.com/microsoft/rushstack.git
-│  │  └─ VendorUrl: https://rushstack.io/
-│  ├─ @sinclair/typebox@0.24.51
-│  │  ├─ URL: https://github.com/sinclairzx81/typebox
-│  │  └─ VendorName: sinclairzx81
-│  ├─ @sinclair/typebox@0.25.21
-│  │  ├─ URL: https://github.com/sinclairzx81/typebox
-│  │  └─ VendorName: sinclairzx81
-│  ├─ @svgr/babel-plugin-add-jsx-attribute@5.4.0
-│  │  ├─ URL: https://github.com/gregberge/svgr/tree/master/packages/babel-plugin-add-jsx-attribute
-│  │  ├─ VendorName: Greg Bergé
-│  │  └─ VendorUrl: https://react-svgr.com/
-│  ├─ @svgr/babel-plugin-remove-jsx-attribute@5.4.0
-│  │  ├─ URL: https://github.com/gregberge/svgr/tree/master/packages/babel-plugin-remove-jsx-attribute
-│  │  ├─ VendorName: Greg Bergé
-│  │  └─ VendorUrl: https://react-svgr.com/
-│  ├─ @svgr/babel-plugin-remove-jsx-empty-expression@5.0.1
-│  │  ├─ URL: https://github.com/gregberge/svgr/tree/master/packages/babel-plugin-remove-jsx-empty-expression
-│  │  ├─ VendorName: Greg Bergé
-│  │  └─ VendorUrl: https://react-svgr.com/
-│  ├─ @svgr/babel-plugin-replace-jsx-attribute-value@5.0.1
-│  │  ├─ URL: https://github.com/gregberge/svgr/tree/master/packages/babel-plugin-replace-jsx-attribute-value
-│  │  ├─ VendorName: Greg Bergé
-│  │  └─ VendorUrl: https://react-svgr.com/
-│  ├─ @svgr/babel-plugin-svg-dynamic-title@5.4.0
-│  │  ├─ URL: https://github.com/gregberge/svgr/tree/master/packages/babel-plugin-svg-dynamic-title
-│  │  ├─ VendorName: Greg Bergé
-│  │  └─ VendorUrl: https://react-svgr.com/
-│  ├─ @svgr/babel-plugin-svg-em-dimensions@5.4.0
-│  │  ├─ URL: https://github.com/gregberge/svgr/tree/master/packages/babel-plugin-svg-em-dimensions
-│  │  ├─ VendorName: Greg Bergé
-│  │  └─ VendorUrl: https://react-svgr.com/
-│  ├─ @svgr/babel-plugin-transform-react-native-svg@5.4.0
-│  │  ├─ URL: https://github.com/gregberge/svgr/tree/master/packages/babel-plugin-transform-react-native-svg
-│  │  ├─ VendorName: Greg Bergé
-│  │  └─ VendorUrl: https://react-svgr.com/
-│  ├─ @svgr/babel-plugin-transform-svg-component@5.5.0
-│  │  ├─ URL: https://github.com/gregberge/svgr/tree/master/packages/babel-plugin-transform-svg-component
-│  │  ├─ VendorName: Greg Bergé
-│  │  └─ VendorUrl: https://react-svgr.com/
-│  ├─ @svgr/babel-preset@5.5.0
-│  │  ├─ URL: https://github.com/gregberge/svgr/tree/master/packages/babel-preset
-│  │  ├─ VendorName: Greg Bergé
-│  │  └─ VendorUrl: https://react-svgr.com/
-│  ├─ @svgr/core@5.5.0
-│  │  ├─ URL: https://github.com/gregberge/svgr/tree/master/packages/core
-│  │  ├─ VendorName: Greg Bergé
-│  │  └─ VendorUrl: https://react-svgr.com/
-│  ├─ @svgr/hast-util-to-babel-ast@5.5.0
-│  │  ├─ URL: https://github.com/gregberge/svgr/tree/master/packages/hast-util-to-babel-ast
-│  │  ├─ VendorName: Greg Bergé
-│  │  └─ VendorUrl: https://react-svgr.com/
-│  ├─ @svgr/plugin-jsx@5.5.0
-│  │  ├─ URL: https://github.com/gregberge/svgr/tree/master/packages/plugin-jsx
-│  │  ├─ VendorName: Greg Bergé
-│  │  └─ VendorUrl: https://react-svgr.com/
-│  ├─ @svgr/plugin-svgo@5.5.0
-│  │  ├─ URL: https://github.com/gregberge/svgr/tree/master/packages/plugin-svgo
-│  │  ├─ VendorName: Greg Bergé
-│  │  └─ VendorUrl: https://react-svgr.com/
-│  ├─ @svgr/webpack@5.5.0
-│  │  ├─ URL: https://github.com/gregberge/svgr/tree/master/packages/webpack
-│  │  ├─ VendorName: Greg Bergé
-│  │  └─ VendorUrl: https://react-svgr.com/
-│  ├─ @swc/helpers@0.4.14
-│  │  ├─ URL: git+https://github.com/swc-project/swc.git
-│  │  ├─ VendorName: 강동윤
-│  │  └─ VendorUrl: https://swc.rs/
-│  ├─ @testing-library/dom@8.20.0
-│  │  ├─ URL: https://github.com/testing-library/dom-testing-library
-│  │  ├─ VendorName: Kent C. Dodds
-│  │  └─ VendorUrl: https://github.com/testing-library/dom-testing-library#readme
-│  ├─ @testing-library/jest-dom@5.16.5
-│  │  ├─ URL: https://github.com/testing-library/jest-dom
-│  │  ├─ VendorName: Ernesto Garcia
-│  │  └─ VendorUrl: https://github.com/testing-library/jest-dom#readme
-│  ├─ @testing-library/react@13.4.0
-│  │  ├─ URL: https://github.com/testing-library/react-testing-library
-│  │  ├─ VendorName: Kent C. Dodds
-│  │  └─ VendorUrl: https://github.com/testing-library/react-testing-library#readme
-│  ├─ @testing-library/user-event@13.5.0
-│  │  ├─ URL: https://github.com/testing-library/user-event
-│  │  ├─ VendorName: Giorgio Polvara
-│  │  └─ VendorUrl: https://github.com/testing-library/user-event#readme
-│  ├─ @tootallnate/once@1.1.2
-│  │  ├─ URL: git://github.com/TooTallNate/once.git
-│  │  ├─ VendorName: Nathan Rajlich
-│  │  └─ VendorUrl: http://n8.io/
-│  ├─ @types/aria-query@5.0.1
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/aria-query
-│  ├─ @types/babel__core@7.20.0
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/babel__core
-│  ├─ @types/babel__generator@7.6.4
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/babel__generator
-│  ├─ @types/babel__template@7.4.1
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/babel__template
-│  ├─ @types/babel__traverse@7.18.3
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/babel__traverse
-│  ├─ @types/body-parser@1.19.2
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/body-parser
-│  ├─ @types/bonjour@3.5.10
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/bonjour
-│  ├─ @types/connect-history-api-fallback@1.3.5
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/connect-history-api-fallback
-│  ├─ @types/connect@3.4.35
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/connect
-│  ├─ @types/eslint-scope@3.7.4
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/eslint-scope
-│  ├─ @types/eslint@8.21.0
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/eslint
-│  ├─ @types/estree@0.0.39
-│  │  └─ URL: https://www.github.com/DefinitelyTyped/DefinitelyTyped.git
-│  ├─ @types/estree@0.0.51
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/estree
-│  ├─ @types/estree@1.0.0
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/estree
-│  ├─ @types/express-serve-static-core@4.17.33
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/express-serve-static-core
-│  ├─ @types/express@4.17.17
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/express
-│  ├─ @types/graceful-fs@4.1.6
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/graceful-fs
-│  ├─ @types/history@4.7.11
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/history
-│  ├─ @types/hoist-non-react-statics@3.3.1
-│  │  └─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  ├─ @types/html-minifier-terser@6.1.0
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/html-minifier-terser
-│  ├─ @types/http-proxy@1.17.9
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/http-proxy
-│  ├─ @types/istanbul-lib-coverage@2.0.4
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/istanbul-lib-coverage
-│  ├─ @types/istanbul-lib-report@3.0.0
-│  │  └─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  ├─ @types/istanbul-reports@3.0.1
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/istanbul-reports
-│  ├─ @types/jest@27.5.2
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/jest
-│  ├─ @types/jest@29.4.0
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/jest
-│  ├─ @types/json-schema@7.0.11
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/json-schema
-│  ├─ @types/json5@0.0.29
-│  │  ├─ URL: https://www.github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorName: Jason Swearingen
-│  ├─ @types/mime@3.0.1
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/mime
-│  ├─ @types/node@17.0.45
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node
-│  ├─ @types/node@18.11.19
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node
-│  ├─ @types/parse-json@4.0.0
-│  │  └─ URL: https://www.github.com/DefinitelyTyped/DefinitelyTyped.git
-│  ├─ @types/prettier@2.7.2
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/prettier
-│  ├─ @types/prop-types@15.7.5
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/prop-types
-│  ├─ @types/q@1.5.5
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/q
-│  ├─ @types/qs@6.9.7
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/qs
-│  ├─ @types/range-parser@1.2.4
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/range-parser
-│  ├─ @types/react-dom@18.0.10
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-dom
-│  ├─ @types/react-is@17.0.3
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-is
-│  ├─ @types/react-redux@7.1.25
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-redux
-│  ├─ @types/react-router-dom@5.3.3
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-router-dom
-│  ├─ @types/react-router@5.1.20
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-router
-│  ├─ @types/react-transition-group@4.4.5
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-transition-group
-│  ├─ @types/react@18.0.27
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react
-│  ├─ @types/redux-actions@2.6.2
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/redux-actions
-│  ├─ @types/resolve@1.17.1
-│  │  └─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  ├─ @types/retry@0.12.0
-│  │  └─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  ├─ @types/scheduler@0.16.2
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/scheduler
-│  ├─ @types/semver@7.3.13
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/semver
-│  ├─ @types/serve-index@1.9.1
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/serve-index
-│  ├─ @types/serve-static@1.15.0
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/serve-static
-│  ├─ @types/sockjs@0.3.33
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/sockjs
-│  ├─ @types/stack-utils@2.0.1
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/stack-utils
-│  ├─ @types/testing-library__jest-dom@5.14.5
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__jest-dom
-│  ├─ @types/trusted-types@2.0.2
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/trusted-types
-│  ├─ @types/warning@3.0.0
-│  │  ├─ URL: https://www.github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorName: Chi Vinh Le
-│  ├─ @types/ws@8.5.4
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/ws
-│  ├─ @types/yargs-parser@21.0.0
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/yargs-parser
-│  ├─ @types/yargs@16.0.5
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/yargs
-│  ├─ @types/yargs@17.0.22
-│  │  ├─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
-│  │  └─ VendorUrl: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/yargs
-│  ├─ @typescript-eslint/eslint-plugin@5.51.0
-│  │  └─ URL: https://github.com/typescript-eslint/typescript-eslint.git
-│  ├─ @typescript-eslint/experimental-utils@5.51.0
-│  │  └─ URL: https://github.com/typescript-eslint/typescript-eslint.git
-│  ├─ @typescript-eslint/scope-manager@5.51.0
-│  │  └─ URL: https://github.com/typescript-eslint/typescript-eslint.git
-│  ├─ @typescript-eslint/type-utils@5.51.0
-│  │  └─ URL: https://github.com/typescript-eslint/typescript-eslint.git
-│  ├─ @typescript-eslint/types@5.51.0
-│  │  └─ URL: https://github.com/typescript-eslint/typescript-eslint.git
-│  ├─ @typescript-eslint/utils@5.51.0
-│  │  └─ URL: https://github.com/typescript-eslint/typescript-eslint.git
-│  ├─ @typescript-eslint/visitor-keys@5.51.0
-│  │  └─ URL: https://github.com/typescript-eslint/typescript-eslint.git
-│  ├─ @webassemblyjs/ast@1.11.1
-│  │  ├─ URL: https://github.com/xtuc/webassemblyjs.git
-│  │  └─ VendorName: Sven Sauleau
-│  ├─ @webassemblyjs/floating-point-hex-parser@1.11.1
-│  │  ├─ URL: https://github.com/xtuc/webassemblyjs.git
-│  │  └─ VendorName: Mauro Bringolf
-│  ├─ @webassemblyjs/helper-api-error@1.11.1
-│  │  ├─ URL: https://github.com/xtuc/webassemblyjs.git
-│  │  └─ VendorName: Sven Sauleau
-│  ├─ @webassemblyjs/helper-buffer@1.11.1
-│  │  ├─ URL: https://github.com/xtuc/webassemblyjs.git
-│  │  └─ VendorName: Sven Sauleau
-│  ├─ @webassemblyjs/helper-numbers@1.11.1
-│  │  ├─ URL: https://github.com/xtuc/webassemblyjs.git
-│  │  └─ VendorName: Sven Sauleau
-│  ├─ @webassemblyjs/helper-wasm-bytecode@1.11.1
-│  │  ├─ URL: https://github.com/xtuc/webassemblyjs.git
-│  │  └─ VendorName: Sven Sauleau
-│  ├─ @webassemblyjs/helper-wasm-section@1.11.1
-│  │  ├─ URL: https://github.com/xtuc/webassemblyjs.git
-│  │  └─ VendorName: Sven Sauleau
-│  ├─ @webassemblyjs/ieee754@1.11.1
-│  │  └─ URL: https://github.com/xtuc/webassemblyjs.git
-│  ├─ @webassemblyjs/utf8@1.11.1
-│  │  ├─ URL: https://github.com/xtuc/webassemblyjs.git
-│  │  └─ VendorName: Sven Sauleau
-│  ├─ @webassemblyjs/wasm-edit@1.11.1
-│  │  ├─ URL: https://github.com/xtuc/webassemblyjs.git
-│  │  └─ VendorName: Sven Sauleau
-│  ├─ @webassemblyjs/wasm-gen@1.11.1
-│  │  ├─ URL: https://github.com/xtuc/webassemblyjs.git
-│  │  └─ VendorName: Sven Sauleau
-│  ├─ @webassemblyjs/wasm-opt@1.11.1
-│  │  ├─ URL: https://github.com/xtuc/webassemblyjs.git
-│  │  └─ VendorName: Sven Sauleau
-│  ├─ @webassemblyjs/wasm-parser@1.11.1
-│  │  ├─ URL: https://github.com/xtuc/webassemblyjs.git
-│  │  └─ VendorName: Sven Sauleau
-│  ├─ @webassemblyjs/wast-printer@1.11.1
-│  │  ├─ URL: https://github.com/xtuc/webassemblyjs.git
-│  │  └─ VendorName: Sven Sauleau
-│  ├─ accepts@1.3.8
-│  │  └─ URL: https://github.com/jshttp/accepts.git
-│  ├─ acorn-globals@6.0.0
-│  │  ├─ URL: https://github.com/ForbesLindesay/acorn-globals.git
-│  │  └─ VendorName: ForbesLindesay
-│  ├─ acorn-import-assertions@1.8.0
-│  │  ├─ URL: https://github.com/xtuc/acorn-import-assertions
-│  │  └─ VendorName: Sven Sauleau
-│  ├─ acorn-jsx@5.3.2
-│  │  ├─ URL: https://github.com/acornjs/acorn-jsx
-│  │  └─ VendorUrl: https://github.com/acornjs/acorn-jsx
-│  ├─ acorn-walk@7.2.0
-│  │  ├─ URL: https://github.com/acornjs/acorn.git
-│  │  └─ VendorUrl: https://github.com/acornjs/acorn
-│  ├─ acorn@7.4.1
-│  │  ├─ URL: https://github.com/acornjs/acorn.git
-│  │  └─ VendorUrl: https://github.com/acornjs/acorn
-│  ├─ acorn@8.8.2
-│  │  ├─ URL: https://github.com/acornjs/acorn.git
-│  │  └─ VendorUrl: https://github.com/acornjs/acorn
-│  ├─ address@1.2.2
-│  │  ├─ URL: git://github.com/node-modules/address.git
-│  │  └─ VendorName: fengmk2
-│  ├─ adjust-sourcemap-loader@4.0.0
-│  │  ├─ URL: git+https://github.com/bholloway/adjust-sourcemap-loader.git
-│  │  ├─ VendorName: bholloway
-│  │  └─ VendorUrl: https://github.com/bholloway/adjust-sourcemap-loader
-│  ├─ agent-base@6.0.2
-│  │  ├─ URL: git://github.com/TooTallNate/node-agent-base.git
-│  │  ├─ VendorName: Nathan Rajlich
-│  │  └─ VendorUrl: http://n8.io/
-│  ├─ ajv-formats@2.1.1
-│  │  ├─ URL: git+https://github.com/ajv-validator/ajv-formats.git
-│  │  ├─ VendorName: Evgeny Poberezkin
-│  │  └─ VendorUrl: https://github.com/ajv-validator/ajv-formats#readme
-│  ├─ ajv-keywords@3.5.2
-│  │  ├─ URL: git+https://github.com/epoberezkin/ajv-keywords.git
-│  │  ├─ VendorName: Evgeny Poberezkin
-│  │  └─ VendorUrl: https://github.com/epoberezkin/ajv-keywords#readme
-│  ├─ ajv-keywords@5.1.0
-│  │  ├─ URL: git+https://github.com/epoberezkin/ajv-keywords.git
-│  │  ├─ VendorName: Evgeny Poberezkin
-│  │  └─ VendorUrl: https://github.com/epoberezkin/ajv-keywords#readme
-│  ├─ ajv@6.12.6
-│  │  ├─ URL: https://github.com/ajv-validator/ajv.git
-│  │  ├─ VendorName: Evgeny Poberezkin
-│  │  └─ VendorUrl: https://github.com/ajv-validator/ajv
-│  ├─ ajv@8.12.0
-│  │  ├─ URL: https://github.com/ajv-validator/ajv.git
-│  │  ├─ VendorName: Evgeny Poberezkin
-│  │  └─ VendorUrl: https://ajv.js.org/
-│  ├─ ansi-colors@4.1.3
-│  │  ├─ URL: https://github.com/doowb/ansi-colors.git
-│  │  ├─ VendorName: Brian Woodward
-│  │  └─ VendorUrl: https://github.com/doowb/ansi-colors
-│  ├─ ansi-escapes@4.3.2
-│  │  ├─ URL: https://github.com/sindresorhus/ansi-escapes.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ ansi-regex@5.0.1
-│  │  ├─ URL: https://github.com/chalk/ansi-regex.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ ansi-regex@6.0.1
-│  │  ├─ URL: https://github.com/chalk/ansi-regex.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ ansi-styles@3.2.1
-│  │  ├─ URL: https://github.com/chalk/ansi-styles.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ ansi-styles@4.3.0
-│  │  ├─ URL: https://github.com/chalk/ansi-styles.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ ansi-styles@5.2.0
-│  │  ├─ URL: https://github.com/chalk/ansi-styles.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ arg@5.0.2
-│  │  ├─ URL: https://github.com/vercel/arg.git
-│  │  └─ VendorName: Josh Junon
-│  ├─ argparse@1.0.10
-│  │  └─ URL: https://github.com/nodeca/argparse.git
-│  ├─ array-flatten@1.1.1
-│  │  ├─ URL: git://github.com/blakeembrey/array-flatten.git
-│  │  ├─ VendorName: Blake Embrey
-│  │  └─ VendorUrl: https://github.com/blakeembrey/array-flatten
-│  ├─ array-flatten@2.1.2
-│  │  ├─ URL: git://github.com/blakeembrey/array-flatten.git
-│  │  ├─ VendorName: Blake Embrey
-│  │  └─ VendorUrl: https://github.com/blakeembrey/array-flatten
-│  ├─ array-includes@3.1.6
-│  │  ├─ URL: git://github.com/es-shims/array-includes.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: http://ljharb.codes
-│  ├─ array-union@2.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/array-union.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ array.prototype.flat@1.3.1
-│  │  ├─ URL: git://github.com/es-shims/Array.prototype.flat.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: http://ljharb.codes
-│  ├─ array.prototype.flatmap@1.3.1
-│  │  ├─ URL: git://github.com/es-shims/Array.prototype.flatMap.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: http://ljharb.codes
-│  ├─ array.prototype.reduce@1.0.5
-│  │  ├─ URL: git+https://github.com/es-shims/Array.prototype.reduce.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/es-shims/Array.prototype.reduce#readme
-│  ├─ array.prototype.tosorted@1.1.1
-│  │  ├─ URL: git+https://github.com/es-shims/Array.prototype.toSorted.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/es-shims/Array.prototype.toSorted#readme
-│  ├─ asap@2.0.6
-│  │  └─ URL: https://github.com/kriskowal/asap.git
-│  ├─ astral-regex@2.0.0
-│  │  ├─ URL: https://github.com/kevva/astral-regex.git
-│  │  ├─ VendorName: Kevin Mårtensson
-│  │  └─ VendorUrl: github.com/kevva
-│  ├─ async@3.2.4
-│  │  ├─ URL: https://github.com/caolan/async.git
-│  │  ├─ VendorName: Caolan McMahon
-│  │  └─ VendorUrl: https://caolan.github.io/async/
-│  ├─ asynckit@0.4.0
-│  │  ├─ URL: git+https://github.com/alexindigo/asynckit.git
-│  │  ├─ VendorName: Alex Indigo
-│  │  └─ VendorUrl: https://github.com/alexindigo/asynckit#readme
-│  ├─ attr-accept@2.2.2
-│  │  ├─ URL: https://github.com/react-dropzone/attr-accept.git
-│  │  ├─ VendorName: Andrey Okonetchnikov @okonetchnikov
-│  │  └─ VendorUrl: https://github.com/react-dropzone/attr-accept#readme
-│  ├─ autoprefixer@10.4.13
-│  │  ├─ URL: https://github.com/postcss/autoprefixer.git
-│  │  └─ VendorName: Andrey Sitnik
-│  ├─ available-typed-arrays@1.0.5
-│  │  ├─ URL: git+https://github.com/inspect-js/available-typed-arrays.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/available-typed-arrays#readme
-│  ├─ axios@0.27.2
-│  │  ├─ URL: https://github.com/axios/axios.git
-│  │  ├─ VendorName: Matt Zabriskie
-│  │  └─ VendorUrl: https://axios-http.com/
-│  ├─ babel-jest@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ babel-loader@8.3.0
-│  │  ├─ URL: https://github.com/babel/babel-loader.git
-│  │  ├─ VendorName: Luis Couto
-│  │  └─ VendorUrl: https://github.com/babel/babel-loader
-│  ├─ babel-plugin-jest-hoist@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ babel-plugin-macros@3.1.0
-│  │  ├─ URL: https://github.com/kentcdodds/babel-plugin-macros
-│  │  ├─ VendorName: Kent C. Dodds
-│  │  └─ VendorUrl: https://github.com/kentcdodds/babel-plugin-macros#readme
-│  ├─ babel-plugin-named-asset-import@0.3.8
-│  │  └─ URL: https://github.com/facebook/create-react-app.git
-│  ├─ babel-plugin-polyfill-corejs2@0.3.3
-│  │  └─ URL: https://github.com/babel/babel-polyfills.git
-│  ├─ babel-plugin-polyfill-corejs3@0.6.0
-│  │  └─ URL: https://github.com/babel/babel-polyfills.git
-│  ├─ babel-plugin-polyfill-regenerator@0.4.1
-│  │  └─ URL: https://github.com/babel/babel-polyfills.git
-│  ├─ babel-plugin-styled-components@2.0.7
-│  │  ├─ URL: https://github.com/styled-components/babel-plugin-styled-components.git
-│  │  └─ VendorUrl: https://styled-components.com/docs/tooling#babel-plugin
-│  ├─ babel-plugin-syntax-jsx@6.18.0
-│  │  └─ URL: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-jsx
-│  ├─ babel-plugin-transform-react-remove-prop-types@0.4.24
-│  │  ├─ URL: https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types.git
-│  │  └─ VendorName: Nikita Gusakov
-│  ├─ babel-preset-current-node-syntax@1.0.1
-│  │  ├─ URL: https://github.com/nicolo-ribaudo/babel-preset-current-node-syntax.git
-│  │  ├─ VendorName: Nicolò Ribaudo
-│  │  └─ VendorUrl: https://github.com/nicolo-ribaudo
-│  ├─ babel-preset-jest@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ babel-preset-react-app@10.0.1
-│  │  └─ URL: https://github.com/facebook/create-react-app.git
-│  ├─ balanced-match@1.0.2
-│  │  ├─ URL: git://github.com/juliangruber/balanced-match.git
-│  │  ├─ VendorName: Julian Gruber
-│  │  └─ VendorUrl: https://github.com/juliangruber/balanced-match
-│  ├─ base64-js@1.3.1
-│  │  ├─ URL: git://github.com/beatgammit/base64-js.git
-│  │  ├─ VendorName: T. Jameson Little
-│  │  └─ VendorUrl: https://github.com/beatgammit/base64-js
-│  ├─ batch@0.6.1
-│  │  ├─ URL: https://github.com/visionmedia/batch.git
-│  │  └─ VendorName: TJ Holowaychuk
-│  ├─ bfj@7.0.2
-│  │  ├─ URL: https://gitlab.com/philbooth/bfj.git
-│  │  ├─ VendorName: Phil Booth
-│  │  └─ VendorUrl: https://gitlab.com/philbooth/bfj
-│  ├─ big.js@5.2.2
-│  │  ├─ URL: https://github.com/MikeMcl/big.js.git
-│  │  └─ VendorName: Michael Mclaughlin
-│  ├─ binary-extensions@2.2.0
-│  │  ├─ URL: https://github.com/sindresorhus/binary-extensions.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ bluebird@3.7.2
-│  │  ├─ URL: git://github.com/petkaantonov/bluebird.git
-│  │  ├─ VendorName: Petka Antonov
-│  │  └─ VendorUrl: https://github.com/petkaantonov/bluebird
-│  ├─ body-parser@1.20.1
-│  │  └─ URL: https://github.com/expressjs/body-parser.git
-│  ├─ bonjour-service@1.1.0
-│  │  ├─ URL: https://github.com/onlxltd/bonjour-service.git
-│  │  ├─ VendorName: ON LX Lited
-│  │  └─ VendorUrl: https://github.com/onlxltd/bonjour-service
-│  ├─ bootstrap@5.2.3
-│  │  ├─ URL: git+https://github.com/twbs/bootstrap.git
-│  │  ├─ VendorName: The Bootstrap Authors
-│  │  └─ VendorUrl: https://getbootstrap.com/
-│  ├─ brace-expansion@1.1.11
-│  │  ├─ URL: git://github.com/juliangruber/brace-expansion.git
-│  │  ├─ VendorName: Julian Gruber
-│  │  └─ VendorUrl: https://github.com/juliangruber/brace-expansion
-│  ├─ brace-expansion@2.0.1
-│  │  ├─ URL: git://github.com/juliangruber/brace-expansion.git
-│  │  ├─ VendorName: Julian Gruber
-│  │  └─ VendorUrl: https://github.com/juliangruber/brace-expansion
-│  ├─ braces@3.0.2
-│  │  ├─ URL: https://github.com/micromatch/braces.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/micromatch/braces
-│  ├─ browserslist@4.21.5
-│  │  ├─ URL: https://github.com/browserslist/browserslist.git
-│  │  └─ VendorName: Andrey Sitnik
-│  ├─ buffer-from@1.1.2
-│  │  └─ URL: https://github.com/LinusU/buffer-from.git
-│  ├─ builtin-modules@3.3.0
-│  │  ├─ URL: https://github.com/sindresorhus/builtin-modules.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ bytes@3.0.0
-│  │  ├─ URL: https://github.com/visionmedia/bytes.js.git
-│  │  ├─ VendorName: TJ Holowaychuk
-│  │  └─ VendorUrl: http://tjholowaychuk.com
-│  ├─ bytes@3.1.2
-│  │  ├─ URL: https://github.com/visionmedia/bytes.js.git
-│  │  ├─ VendorName: TJ Holowaychuk
-│  │  └─ VendorUrl: http://tjholowaychuk.com
-│  ├─ call-bind@1.0.2
-│  │  ├─ URL: git+https://github.com/ljharb/call-bind.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/ljharb/call-bind#readme
-│  ├─ callsites@3.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/callsites.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ camel-case@4.1.2
-│  │  ├─ URL: git://github.com/blakeembrey/change-case.git
-│  │  ├─ VendorName: Blake Embrey
-│  │  └─ VendorUrl: https://github.com/blakeembrey/change-case/tree/master/packages/camel-case#readme
-│  ├─ camelcase-css@2.0.1
-│  │  ├─ URL: https://github.com/stevenvachon/camelcase-css.git
-│  │  ├─ VendorName: Steven Vachon
-│  │  └─ VendorUrl: https://www.svachon.com/
-│  ├─ camelcase@5.3.1
-│  │  ├─ URL: https://github.com/sindresorhus/camelcase.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ camelcase@6.3.0
-│  │  ├─ URL: https://github.com/sindresorhus/camelcase.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ camelize@1.0.1
-│  │  ├─ URL: git://github.com/ljharb/camelize.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: https://github.com/ljharb/camelize
-│  ├─ caniuse-api@3.0.0
-│  │  └─ URL: https://github.com/nyalab/caniuse-api.git
-│  ├─ case-sensitive-paths-webpack-plugin@2.4.0
-│  │  ├─ URL: git+https://github.com/Urthen/case-sensitive-paths-webpack-plugin.git
-│  │  ├─ VendorName: Michael Pratt
-│  │  └─ VendorUrl: https://github.com/Urthen/case-sensitive-paths-webpack-plugin#readme
-│  ├─ chalk@2.4.2
-│  │  └─ URL: https://github.com/chalk/chalk.git
-│  ├─ chalk@3.0.0
-│  │  └─ URL: https://github.com/chalk/chalk.git
-│  ├─ chalk@4.1.2
-│  │  └─ URL: https://github.com/chalk/chalk.git
-│  ├─ char-regex@1.0.2
-│  │  ├─ URL: https://github.com/Richienb/char-regex.git
-│  │  └─ VendorName: Richie Bendall
-│  ├─ char-regex@2.0.1
-│  │  ├─ URL: https://github.com/Richienb/char-regex.git
-│  │  └─ VendorName: Richie Bendall
-│  ├─ check-types@11.2.2
-│  │  ├─ URL: https://gitlab.com/philbooth/check-types.js.git
-│  │  ├─ VendorName: Phil Booth
-│  │  └─ VendorUrl: https://gitlab.com/philbooth/check-types.js
-│  ├─ chokidar@3.5.3
-│  │  ├─ URL: git+https://github.com/paulmillr/chokidar.git
-│  │  ├─ VendorName: Paul Miller
-│  │  └─ VendorUrl: https://github.com/paulmillr/chokidar
-│  ├─ chrome-trace-event@1.0.3
-│  │  ├─ URL: https://github.com/samccone/chrome-trace-event.git
-│  │  └─ VendorName: Trent Mick, Sam Saccone
-│  ├─ ci-info@3.7.1
-│  │  ├─ URL: https://github.com/watson/ci-info.git
-│  │  ├─ VendorName: Thomas Watson Steen
-│  │  └─ VendorUrl: https://github.com/watson/ci-info
-│  ├─ cjs-module-lexer@1.2.2
-│  │  ├─ URL: git+https://github.com/guybedford/cjs-module-lexer.git
-│  │  ├─ VendorName: Guy Bedford
-│  │  └─ VendorUrl: https://github.com/guybedford/cjs-module-lexer#readme
-│  ├─ classnames@2.3.2
-│  │  ├─ URL: https://github.com/JedWatson/classnames.git
-│  │  └─ VendorName: Jed Watson
-│  ├─ clean-css@5.3.2
-│  │  ├─ URL: https://github.com/clean-css/clean-css.git
-│  │  ├─ VendorName: Jakub Pawlowicz
-│  │  └─ VendorUrl: https://github.com/clean-css/clean-css
-│  ├─ clsx@1.2.1
-│  │  ├─ URL: https://github.com/lukeed/clsx.git
-│  │  ├─ VendorName: Luke Edwards
-│  │  └─ VendorUrl: https://lukeed.com
-│  ├─ co@4.6.0
-│  │  └─ URL: https://github.com/tj/co.git
-│  ├─ coa@2.0.2
-│  │  ├─ URL: git://github.com/veged/coa.git
-│  │  ├─ VendorName: Sergey Berezhnoy
-│  │  └─ VendorUrl: http://github.com/veged/coa
-│  ├─ collect-v8-coverage@1.0.1
-│  │  └─ URL: https://github.com/SimenB/collect-v8-coverage.git
-│  ├─ color-convert@1.9.3
-│  │  ├─ URL: https://github.com/Qix-/color-convert.git
-│  │  └─ VendorName: Heather Arthur
-│  ├─ color-convert@2.0.1
-│  │  ├─ URL: https://github.com/Qix-/color-convert.git
-│  │  └─ VendorName: Heather Arthur
-│  ├─ color-name@1.1.3
-│  │  ├─ URL: git@github.com:dfcreative/color-name.git
-│  │  ├─ VendorName: DY
-│  │  └─ VendorUrl: https://github.com/dfcreative/color-name
-│  ├─ color-name@1.1.4
-│  │  ├─ URL: git@github.com:colorjs/color-name.git
-│  │  ├─ VendorName: DY
-│  │  └─ VendorUrl: https://github.com/colorjs/color-name
-│  ├─ colord@2.9.3
-│  │  ├─ URL: https://github.com/omgovich/colord.git
-│  │  └─ VendorName: Vlad Shilov
-│  ├─ colorette@2.0.19
-│  │  ├─ URL: https://github.com/jorgebucaran/colorette.git
-│  │  └─ VendorName: Jorge Bucaran
-│  ├─ combined-stream@1.0.8
-│  │  ├─ URL: git://github.com/felixge/node-combined-stream.git
-│  │  ├─ VendorName: Felix Geisendörfer
-│  │  └─ VendorUrl: https://github.com/felixge/node-combined-stream
-│  ├─ commander@2.20.3
-│  │  ├─ URL: https://github.com/tj/commander.js.git
-│  │  └─ VendorName: TJ Holowaychuk
-│  ├─ commander@7.2.0
-│  │  ├─ URL: https://github.com/tj/commander.js.git
-│  │  └─ VendorName: TJ Holowaychuk
-│  ├─ commander@8.3.0
-│  │  ├─ URL: https://github.com/tj/commander.js.git
-│  │  └─ VendorName: TJ Holowaychuk
-│  ├─ common-tags@1.8.2
-│  │  ├─ URL: https://github.com/zspecza/common-tags
-│  │  ├─ VendorName: Declan de Wet
-│  │  └─ VendorUrl: https://github.com/zspecza/common-tags
-│  ├─ commondir@1.0.1
-│  │  ├─ URL: http://github.com/substack/node-commondir.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: http://substack.net
-│  ├─ compressible@2.0.18
-│  │  └─ URL: https://github.com/jshttp/compressible.git
-│  ├─ compression@1.7.4
-│  │  └─ URL: https://github.com/expressjs/compression.git
-│  ├─ concat-map@0.0.1
-│  │  ├─ URL: git://github.com/substack/node-concat-map.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: http://substack.net
-│  ├─ confusing-browser-globals@1.0.11
-│  │  └─ URL: https://github.com/facebook/create-react-app.git
-│  ├─ connect-history-api-fallback@2.0.0
-│  │  ├─ URL: http://github.com/bripkens/connect-history-api-fallback.git
-│  │  └─ VendorName: Ben Ripkens
-│  ├─ content-disposition@0.5.4
-│  │  ├─ URL: https://github.com/jshttp/content-disposition.git
-│  │  └─ VendorName: Douglas Christopher Wilson
-│  ├─ content-type@1.0.5
-│  │  ├─ URL: https://github.com/jshttp/content-type.git
-│  │  └─ VendorName: Douglas Christopher Wilson
-│  ├─ convert-source-map@1.9.0
-│  │  ├─ URL: git://github.com/thlorenz/convert-source-map.git
-│  │  ├─ VendorName: Thorsten Lorenz
-│  │  └─ VendorUrl: https://github.com/thlorenz/convert-source-map
-│  ├─ cookie-signature@1.0.6
-│  │  ├─ URL: https://github.com/visionmedia/node-cookie-signature.git
-│  │  └─ VendorName: TJ Holowaychuk
-│  ├─ cookie@0.5.0
-│  │  ├─ URL: https://github.com/jshttp/cookie.git
-│  │  └─ VendorName: Roman Shtylman
-│  ├─ core-js-compat@3.27.2
-│  │  ├─ URL: https://github.com/zloirock/core-js.git
-│  │  ├─ VendorName: Denis Pushkarev
-│  │  └─ VendorUrl: http://zloirock.ru
-│  ├─ core-js-pure@3.27.2
-│  │  ├─ URL: https://github.com/zloirock/core-js.git
-│  │  ├─ VendorName: Denis Pushkarev
-│  │  └─ VendorUrl: http://zloirock.ru
-│  ├─ core-js@3.27.2
-│  │  ├─ URL: https://github.com/zloirock/core-js.git
-│  │  ├─ VendorName: Denis Pushkarev
-│  │  └─ VendorUrl: http://zloirock.ru
-│  ├─ core-util-is@1.0.3
-│  │  ├─ URL: git://github.com/isaacs/core-util-is
-│  │  ├─ VendorName: Isaac Z. Schlueter
-│  │  └─ VendorUrl: http://blog.izs.me/
-│  ├─ cosmiconfig@6.0.0
-│  │  ├─ URL: git+https://github.com/davidtheclark/cosmiconfig.git
-│  │  ├─ VendorName: David Clark
-│  │  └─ VendorUrl: https://github.com/davidtheclark/cosmiconfig#readme
-│  ├─ cosmiconfig@7.1.0
-│  │  ├─ URL: git+https://github.com/davidtheclark/cosmiconfig.git
-│  │  ├─ VendorName: David Clark
-│  │  └─ VendorUrl: https://github.com/davidtheclark/cosmiconfig#readme
-│  ├─ cross-spawn@7.0.3
-│  │  ├─ URL: git@github.com:moxystudio/node-cross-spawn.git
-│  │  ├─ VendorName: André Cruz
-│  │  └─ VendorUrl: https://github.com/moxystudio/node-cross-spawn
-│  ├─ crypto-random-string@2.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/crypto-random-string.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ css-loader@6.7.3
-│  │  ├─ URL: https://github.com/webpack-contrib/css-loader.git
-│  │  ├─ VendorName: Tobias Koppers @sokra
-│  │  └─ VendorUrl: https://github.com/webpack-contrib/css-loader
-│  ├─ css-minimizer-webpack-plugin@3.4.1
-│  │  ├─ URL: https://github.com/webpack-contrib/css-minimizer-webpack-plugin.git
-│  │  ├─ VendorName: Loann Neveu
-│  │  └─ VendorUrl: https://github.com/webpack-contrib/css-minimizer-webpack-plugin
-│  ├─ css-select-base-adapter@0.1.1
-│  │  ├─ URL: https://github.com/nrkn/css-select-base-adapter.git
-│  │  ├─ VendorName: Nik Coughlin
-│  │  └─ VendorUrl: https://github.com/nrkn/css-select-base-adapter#readme
-│  ├─ css-to-react-native@3.1.0
-│  │  ├─ URL: git+https://github.com/styled-components/css-to-react-native.git
-│  │  ├─ VendorName: Jacob Parker
-│  │  └─ VendorUrl: https://github.com/styled-components/css-to-react-native#readme
-│  ├─ css-tree@1.0.0-alpha.37
-│  │  ├─ URL: https://github.com/csstree/csstree.git
-│  │  ├─ VendorName: Roman Dvornov
-│  │  └─ VendorUrl: https://github.com/lahmatiy
-│  ├─ css-tree@1.1.3
-│  │  ├─ URL: https://github.com/csstree/csstree.git
-│  │  ├─ VendorName: Roman Dvornov
-│  │  └─ VendorUrl: https://github.com/lahmatiy
-│  ├─ css.escape@1.5.1
-│  │  ├─ URL: https://github.com/mathiasbynens/CSS.escape.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://mths.be/cssescape
-│  ├─ cssesc@3.0.0
-│  │  ├─ URL: https://github.com/mathiasbynens/cssesc.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://mths.be/cssesc
-│  ├─ cssnano-preset-default@5.2.13
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ cssnano-utils@3.1.0
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ cssnano@5.1.14
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ csso@4.2.0
-│  │  ├─ URL: https://github.com/css/csso.git
-│  │  ├─ VendorName: Sergey Kryzhanovsky
-│  │  └─ VendorUrl: https://github.com/css/csso
-│  ├─ cssom@0.3.8
-│  │  ├─ URL: https://github.com/NV/CSSOM.git
-│  │  └─ VendorName: Nikita Vasilyev
-│  ├─ cssom@0.4.4
-│  │  ├─ URL: https://github.com/NV/CSSOM.git
-│  │  └─ VendorName: Nikita Vasilyev
-│  ├─ cssstyle@2.3.0
-│  │  ├─ URL: https://github.com/jsdom/cssstyle.git
-│  │  └─ VendorUrl: https://github.com/jsdom/cssstyle
-│  ├─ csstype@3.1.1
-│  │  ├─ URL: https://github.com/frenic/csstype
-│  │  └─ VendorName: Fredrik Nicol
-│  ├─ data-urls@2.0.0
-│  │  ├─ URL: https://github.com/jsdom/data-urls.git
-│  │  ├─ VendorName: Domenic Denicola
-│  │  └─ VendorUrl: https://domenic.me/
-│  ├─ date-fns@2.29.3
-│  │  └─ URL: https://github.com/date-fns/date-fns
-│  ├─ debug@2.6.9
-│  │  ├─ URL: git://github.com/visionmedia/debug.git
-│  │  └─ VendorName: TJ Holowaychuk
-│  ├─ debug@3.2.7
-│  │  ├─ URL: git://github.com/visionmedia/debug.git
-│  │  └─ VendorName: TJ Holowaychuk
-│  ├─ debug@4.3.4
-│  │  ├─ URL: git://github.com/debug-js/debug.git
-│  │  └─ VendorName: Josh Junon
-│  ├─ decimal.js@10.4.3
-│  │  ├─ URL: https://github.com/MikeMcl/decimal.js.git
-│  │  └─ VendorName: Michael Mclaughlin
-│  ├─ dedent@0.7.0
-│  │  ├─ URL: git://github.com/dmnd/dedent.git
-│  │  ├─ VendorName: Desmond Brand
-│  │  └─ VendorUrl: https://github.com/dmnd/dedent
-│  ├─ deep-equal@2.2.0
-│  │  ├─ URL: http://github.com/inspect-js/node-deep-equal.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: http://substack.net
-│  ├─ deep-is@0.1.4
-│  │  ├─ URL: http://github.com/thlorenz/deep-is.git
-│  │  ├─ VendorName: Thorsten Lorenz
-│  │  └─ VendorUrl: http://thlorenz.com
-│  ├─ deepmerge@4.3.0
-│  │  ├─ URL: git://github.com/TehShrike/deepmerge.git
-│  │  └─ VendorUrl: https://github.com/TehShrike/deepmerge
-│  ├─ define-lazy-prop@2.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/define-lazy-prop.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ define-properties@1.1.4
-│  │  ├─ URL: git://github.com/ljharb/define-properties.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ defined@1.0.1
-│  │  ├─ URL: git://github.com/inspect-js/defined.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: https://github.com/inspect-js/defined
-│  ├─ delayed-stream@1.0.0
-│  │  ├─ URL: git://github.com/felixge/node-delayed-stream.git
-│  │  ├─ VendorName: Felix Geisendörfer
-│  │  └─ VendorUrl: https://github.com/felixge/node-delayed-stream
-│  ├─ depd@1.1.2
-│  │  ├─ URL: https://github.com/dougwilson/nodejs-depd.git
-│  │  └─ VendorName: Douglas Christopher Wilson
-│  ├─ depd@2.0.0
-│  │  ├─ URL: https://github.com/dougwilson/nodejs-depd.git
-│  │  └─ VendorName: Douglas Christopher Wilson
-│  ├─ dequal@2.0.3
-│  │  ├─ URL: https://github.com/lukeed/dequal.git
-│  │  ├─ VendorName: Luke Edwards
-│  │  └─ VendorUrl: https://lukeed.com
-│  ├─ destroy@1.2.0
-│  │  ├─ URL: https://github.com/stream-utils/destroy.git
-│  │  ├─ VendorName: Jonathan Ong
-│  │  └─ VendorUrl: http://jongleberry.com
-│  ├─ detect-newline@3.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/detect-newline.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ detect-node@2.1.0
-│  │  ├─ URL: https://github.com/iliakan/detect-node
-│  │  ├─ VendorName: Ilya Kantor
-│  │  └─ VendorUrl: https://github.com/iliakan/detect-node
-│  ├─ detect-port-alt@1.1.6
-│  │  ├─ URL: git://github.com/node-modules/detect-port.git
-│  │  └─ VendorUrl: https://github.com/node-modules/detect-port
-│  ├─ detective@5.2.1
-│  │  ├─ URL: git://github.com/browserify/detective.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: http://substack.net
-│  ├─ diff-sequences@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ diff-sequences@29.3.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ dir-glob@3.0.1
-│  │  ├─ URL: https://github.com/kevva/dir-glob.git
-│  │  ├─ VendorName: Kevin Mårtensson
-│  │  └─ VendorUrl: github.com/kevva
-│  ├─ dlv@1.1.3
-│  │  ├─ URL: https://github.com/developit/dlv.git
-│  │  ├─ VendorName: Jason Miller
-│  │  └─ VendorUrl: http://jasonformat.com
-│  ├─ dns-equal@1.0.0
-│  │  ├─ URL: git+https://github.com/watson/dns-equal.git
-│  │  ├─ VendorName: Thomas Watson Steen
-│  │  └─ VendorUrl: https://github.com/watson/dns-equal#readme
-│  ├─ dns-packet@5.4.0
-│  │  ├─ URL: https://github.com/mafintosh/dns-packet.git
-│  │  ├─ VendorName: Mathias Buus
-│  │  └─ VendorUrl: https://github.com/mafintosh/dns-packet
-│  ├─ dom-accessibility-api@0.5.16
-│  │  └─ URL: https://github.com/eps1lon/dom-accessibility-api.git
-│  ├─ dom-converter@0.2.0
-│  │  ├─ URL: https://github.com/AriaMinaei/dom-converter
-│  │  └─ VendorName: Aria Minaei
-│  ├─ dom-helpers@5.2.1
-│  │  ├─ URL: git+https://github.com/react-bootstrap/dom-helpers.git
-│  │  ├─ VendorName: Jason Quense
-│  │  └─ VendorUrl: https://github.com/react-bootstrap/dom-helpers#readme
-│  ├─ dom-serializer@0.2.2
-│  │  ├─ URL: git://github.com/cheeriojs/dom-renderer.git
-│  │  └─ VendorName: Felix Boehm
-│  ├─ dom-serializer@1.4.1
-│  │  ├─ URL: git://github.com/cheeriojs/dom-renderer.git
-│  │  └─ VendorName: Felix Boehm
-│  ├─ domexception@2.0.1
-│  │  ├─ URL: https://github.com/jsdom/domexception.git
-│  │  ├─ VendorName: Domenic Denicola
-│  │  └─ VendorUrl: https://domenic.me/
-│  ├─ dot-case@3.0.4
-│  │  ├─ URL: git://github.com/blakeembrey/change-case.git
-│  │  ├─ VendorName: Blake Embrey
-│  │  └─ VendorUrl: https://github.com/blakeembrey/change-case/tree/master/packages/dot-case#readme
-│  ├─ duplexer@0.1.2
-│  │  ├─ URL: git://github.com/Raynos/duplexer.git
-│  │  ├─ VendorName: Raynos
-│  │  └─ VendorUrl: https://github.com/Raynos/duplexer
-│  ├─ ee-first@1.1.1
-│  │  ├─ URL: https://github.com/jonathanong/ee-first.git
-│  │  ├─ VendorName: Jonathan Ong
-│  │  └─ VendorUrl: http://jongleberry.com
-│  ├─ emittery@0.10.2
-│  │  ├─ URL: https://github.com/sindresorhus/emittery.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ emittery@0.8.1
-│  │  ├─ URL: https://github.com/sindresorhus/emittery.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ emoji-regex@8.0.0
-│  │  ├─ URL: https://github.com/mathiasbynens/emoji-regex.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://mths.be/emoji-regex
-│  ├─ emoji-regex@9.2.2
-│  │  ├─ URL: https://github.com/mathiasbynens/emoji-regex.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://mths.be/emoji-regex
-│  ├─ emojis-list@3.0.0
-│  │  ├─ URL: git+https://github.com/kikobeats/emojis-list.git
-│  │  ├─ VendorName: Kiko Beats
-│  │  └─ VendorUrl: https://nidecoc.io/Kikobeats/emojis-list
-│  ├─ encodeurl@1.0.2
-│  │  └─ URL: https://github.com/pillarjs/encodeurl.git
-│  ├─ enhanced-resolve@5.12.0
-│  │  ├─ URL: git://github.com/webpack/enhanced-resolve.git
-│  │  ├─ VendorName: Tobias Koppers @sokra
-│  │  └─ VendorUrl: http://github.com/webpack/enhanced-resolve
-│  ├─ enquirer@2.3.6
-│  │  ├─ URL: https://github.com/enquirer/enquirer.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/enquirer/enquirer
-│  ├─ error-ex@1.3.2
-│  │  └─ URL: https://github.com/qix-/node-error-ex.git
-│  ├─ error-stack-parser@2.1.4
-│  │  ├─ URL: git://github.com/stacktracejs/error-stack-parser.git
-│  │  └─ VendorUrl: https://www.stacktracejs.com/
-│  ├─ es-abstract@1.21.1
-│  │  ├─ URL: git://github.com/ljharb/es-abstract.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: http://ljharb.codes
-│  ├─ es-array-method-boxes-properly@1.0.0
-│  │  ├─ URL: git+https://github.com/ljharb/es-array-method-boxes-properly.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/ljharb/es-array-method-boxes-properly#readme
-│  ├─ es-get-iterator@1.1.3
-│  │  ├─ URL: git+https://github.com/ljharb/es-get-iterator.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/ljharb/es-get-iterator#readme
-│  ├─ es-module-lexer@0.9.3
-│  │  ├─ URL: git+https://github.com/guybedford/es-module-lexer.git
-│  │  ├─ VendorName: Guy Bedford
-│  │  └─ VendorUrl: https://github.com/guybedford/es-module-lexer#readme
-│  ├─ es-set-tostringtag@2.0.1
-│  │  ├─ URL: git+https://github.com/es-shims/es-set-tostringtag.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/es-shims/es-set-tostringtag#readme
-│  ├─ es-shim-unscopables@1.0.0
-│  │  ├─ URL: git+https://github.com/ljharb/es-shim-unscopables.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/ljharb/es-shim-unscopables#readme
-│  ├─ es-to-primitive@1.2.1
-│  │  ├─ URL: git://github.com/ljharb/es-to-primitive.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ escalade@3.1.1
-│  │  ├─ URL: https://github.com/lukeed/escalade.git
-│  │  ├─ VendorName: Luke Edwards
-│  │  └─ VendorUrl: https://lukeed.com
-│  ├─ escape-html@1.0.3
-│  │  └─ URL: https://github.com/component/escape-html.git
-│  ├─ escape-string-regexp@1.0.5
-│  │  ├─ URL: https://github.com/sindresorhus/escape-string-regexp.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ escape-string-regexp@2.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/escape-string-regexp.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ escape-string-regexp@4.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/escape-string-regexp.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ eslint-config-react-app@7.0.1
-│  │  └─ URL: https://github.com/facebook/create-react-app.git
-│  ├─ eslint-import-resolver-node@0.3.7
-│  │  ├─ URL: https://github.com/import-js/eslint-plugin-import
-│  │  ├─ VendorName: Ben Mosher
-│  │  └─ VendorUrl: https://github.com/import-js/eslint-plugin-import
-│  ├─ eslint-module-utils@2.7.4
-│  │  ├─ URL: git+https://github.com/import-js/eslint-plugin-import.git
-│  │  ├─ VendorName: Ben Mosher
-│  │  └─ VendorUrl: https://github.com/import-js/eslint-plugin-import#readme
-│  ├─ eslint-plugin-import@2.27.5
-│  │  ├─ URL: https://github.com/import-js/eslint-plugin-import
-│  │  ├─ VendorName: Ben Mosher
-│  │  └─ VendorUrl: https://github.com/import-js/eslint-plugin-import
-│  ├─ eslint-plugin-jest@25.7.0
-│  │  ├─ URL: https://github.com/jest-community/eslint-plugin-jest.git
-│  │  ├─ VendorName: Jonathan Kim
-│  │  └─ VendorUrl: jkimbo.com
-│  ├─ eslint-plugin-jsx-a11y@6.7.1
-│  │  ├─ URL: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y
-│  │  └─ VendorName: Ethan Cohen
-│  ├─ eslint-plugin-react-hooks@4.6.0
-│  │  ├─ URL: https://github.com/facebook/react.git
-│  │  └─ VendorUrl: https://reactjs.org/
-│  ├─ eslint-plugin-react@7.32.2
-│  │  ├─ URL: https://github.com/jsx-eslint/eslint-plugin-react
-│  │  ├─ VendorName: Yannick Croissant
-│  │  └─ VendorUrl: https://github.com/jsx-eslint/eslint-plugin-react
-│  ├─ eslint-plugin-testing-library@5.10.0
-│  │  ├─ URL: https://github.com/testing-library/eslint-plugin-testing-library
-│  │  ├─ VendorName: Mario Beltrán Alarcón
-│  │  └─ VendorUrl: https://github.com/testing-library/eslint-plugin-testing-library
-│  ├─ eslint-utils@2.1.0
-│  │  ├─ URL: git+https://github.com/mysticatea/eslint-utils.git
-│  │  ├─ VendorName: Toru Nagashima
-│  │  └─ VendorUrl: https://github.com/mysticatea/eslint-utils#readme
-│  ├─ eslint-utils@3.0.0
-│  │  ├─ URL: git+https://github.com/mysticatea/eslint-utils.git
-│  │  ├─ VendorName: Toru Nagashima
-│  │  └─ VendorUrl: https://github.com/mysticatea/eslint-utils#readme
-│  ├─ eslint-webpack-plugin@3.2.0
-│  │  ├─ URL: https://github.com/webpack-contrib/eslint-webpack-plugin.git
-│  │  ├─ VendorName: Ricardo Gobbo de Souza
-│  │  └─ VendorUrl: https://github.com/webpack-contrib/eslint-webpack-plugin
-│  ├─ eslint@7.32.0
-│  │  ├─ URL: https://github.com/eslint/eslint.git
-│  │  ├─ VendorName: Nicholas C. Zakas
-│  │  └─ VendorUrl: https://eslint.org/
-│  ├─ eslint@8.33.0
-│  │  ├─ URL: https://github.com/eslint/eslint.git
-│  │  ├─ VendorName: Nicholas C. Zakas
-│  │  └─ VendorUrl: https://eslint.org/
-│  ├─ estree-walker@1.0.1
-│  │  ├─ URL: https://github.com/Rich-Harris/estree-walker
-│  │  └─ VendorName: Rich Harris
-│  ├─ etag@1.8.1
-│  │  └─ URL: https://github.com/jshttp/etag.git
-│  ├─ eventemitter3@4.0.7
-│  │  ├─ URL: git://github.com/primus/eventemitter3.git
-│  │  └─ VendorName: Arnout Kazemier
-│  ├─ events@3.3.0
-│  │  ├─ URL: git://github.com/Gozala/events.git
-│  │  ├─ VendorName: Irakli Gozalishvili
-│  │  └─ VendorUrl: http://jeditoolkit.com
-│  ├─ execa@5.1.1
-│  │  ├─ URL: https://github.com/sindresorhus/execa.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ exit@0.1.2
-│  │  ├─ URL: git://github.com/cowboy/node-exit.git
-│  │  ├─ VendorName: "Cowboy" Ben Alman
-│  │  └─ VendorUrl: https://github.com/cowboy/node-exit
-│  ├─ expect@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ expect@29.4.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ express@4.18.2
-│  │  ├─ URL: https://github.com/expressjs/express.git
-│  │  ├─ VendorName: TJ Holowaychuk
-│  │  └─ VendorUrl: http://expressjs.com/
-│  ├─ fast-deep-equal@3.1.3
-│  │  ├─ URL: git+https://github.com/epoberezkin/fast-deep-equal.git
-│  │  ├─ VendorName: Evgeny Poberezkin
-│  │  └─ VendorUrl: https://github.com/epoberezkin/fast-deep-equal#readme
-│  ├─ fast-glob@3.2.12
-│  │  ├─ URL: https://github.com/mrmlnc/fast-glob.git
-│  │  ├─ VendorName: Denis Malinochkin
-│  │  └─ VendorUrl: https://mrmlnc.com
-│  ├─ fast-json-stable-stringify@2.1.0
-│  │  ├─ URL: git://github.com/epoberezkin/fast-json-stable-stringify.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: https://github.com/epoberezkin/fast-json-stable-stringify
-│  ├─ fast-levenshtein@2.0.6
-│  │  ├─ URL: https://github.com/hiddentao/fast-levenshtein.git
-│  │  ├─ VendorName: Ramesh Nair
-│  │  └─ VendorUrl: http://www.hiddentao.com/
-│  ├─ file-entry-cache@6.0.1
-│  │  ├─ URL: https://github.com/royriojas/file-entry-cache.git
-│  │  ├─ VendorName: Roy Riojas
-│  │  └─ VendorUrl: http://royriojas.com
-│  ├─ file-loader@6.2.0
-│  │  ├─ URL: https://github.com/webpack-contrib/file-loader.git
-│  │  ├─ VendorName: Tobias Koppers @sokra
-│  │  └─ VendorUrl: https://github.com/webpack-contrib/file-loader
-│  ├─ file-selector@0.4.0
-│  │  ├─ URL: https://github.com/react-dropzone/file-selector.git
-│  │  ├─ VendorName: Roland Groza
-│  │  └─ VendorUrl: https://github.com/react-dropzone/file-selector
-│  ├─ fill-range@7.0.1
-│  │  ├─ URL: https://github.com/jonschlinkert/fill-range.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/jonschlinkert/fill-range
-│  ├─ finalhandler@1.2.0
-│  │  ├─ URL: https://github.com/pillarjs/finalhandler.git
-│  │  └─ VendorName: Douglas Christopher Wilson
-│  ├─ find-cache-dir@3.3.2
-│  │  └─ URL: https://github.com/avajs/find-cache-dir.git
-│  ├─ find-root@1.1.0
-│  │  ├─ URL: git@github.com:js-n/find-root.git
-│  │  └─ VendorName: jsdnxx
-│  ├─ find-up@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/find-up.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ find-up@4.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/find-up.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ find-up@5.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/find-up.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ flat-cache@3.0.4
-│  │  ├─ URL: https://github.com/royriojas/flat-cache.git
-│  │  ├─ VendorName: Roy Riojas
-│  │  └─ VendorUrl: http://royriojas.com
-│  ├─ follow-redirects@1.15.2
-│  │  ├─ URL: git@github.com:follow-redirects/follow-redirects.git
-│  │  ├─ VendorName: Ruben Verborgh
-│  │  └─ VendorUrl: https://github.com/follow-redirects/follow-redirects
-│  ├─ for-each@0.3.3
-│  │  ├─ URL: git://github.com/Raynos/for-each.git
-│  │  ├─ VendorName: Raynos
-│  │  └─ VendorUrl: https://github.com/Raynos/for-each
-│  ├─ fork-ts-checker-webpack-plugin@6.5.2
-│  │  ├─ URL: https://github.com/TypeStrong/fork-ts-checker-webpack-plugin.git
-│  │  └─ VendorName: Piotr Oleś
-│  ├─ form-data@3.0.1
-│  │  ├─ URL: git://github.com/form-data/form-data.git
-│  │  ├─ VendorName: Felix Geisendörfer
-│  │  └─ VendorUrl: http://debuggable.com/
-│  ├─ form-data@4.0.0
-│  │  ├─ URL: git://github.com/form-data/form-data.git
-│  │  ├─ VendorName: Felix Geisendörfer
-│  │  └─ VendorUrl: http://debuggable.com/
-│  ├─ forwarded@0.2.0
-│  │  └─ URL: https://github.com/jshttp/forwarded.git
-│  ├─ fraction.js@4.2.0
-│  │  ├─ URL: git://github.com/infusion/Fraction.js.git
-│  │  ├─ VendorName: Robert Eisele
-│  │  └─ VendorUrl: https://www.xarg.org/2014/03/rational-numbers-in-javascript/
-│  ├─ fresh@0.5.2
-│  │  ├─ URL: https://github.com/jshttp/fresh.git
-│  │  ├─ VendorName: TJ Holowaychuk
-│  │  └─ VendorUrl: http://tjholowaychuk.com
-│  ├─ fs-extra@10.1.0
-│  │  ├─ URL: https://github.com/jprichardson/node-fs-extra
-│  │  ├─ VendorName: JP Richardson
-│  │  └─ VendorUrl: https://github.com/jprichardson/node-fs-extra
-│  ├─ fs-extra@9.1.0
-│  │  ├─ URL: https://github.com/jprichardson/node-fs-extra
-│  │  ├─ VendorName: JP Richardson
-│  │  └─ VendorUrl: https://github.com/jprichardson/node-fs-extra
-│  ├─ function-bind@1.1.1
-│  │  ├─ URL: git://github.com/Raynos/function-bind.git
-│  │  ├─ VendorName: Raynos
-│  │  └─ VendorUrl: https://github.com/Raynos/function-bind
-│  ├─ function.prototype.name@1.1.5
-│  │  ├─ URL: git://github.com/es-shims/Function.prototype.name.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ functional-red-black-tree@1.0.1
-│  │  ├─ URL: git://github.com/mikolalysenko/functional-red-black-tree.git
-│  │  └─ VendorName: Mikola Lysenko
-│  ├─ functions-have-names@1.2.3
-│  │  ├─ URL: git+https://github.com/inspect-js/functions-have-names.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/functions-have-names#readme
-│  ├─ gensync@1.0.0-beta.2
-│  │  ├─ URL: https://github.com/loganfsmyth/gensync.git
-│  │  ├─ VendorName: Logan Smyth
-│  │  └─ VendorUrl: https://github.com/loganfsmyth/gensync
-│  ├─ get-intrinsic@1.2.0
-│  │  ├─ URL: git+https://github.com/ljharb/get-intrinsic.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/ljharb/get-intrinsic#readme
-│  ├─ get-package-type@0.1.0
-│  │  ├─ URL: git+https://github.com/cfware/get-package-type.git
-│  │  ├─ VendorName: Corey Farrell
-│  │  └─ VendorUrl: https://github.com/cfware/get-package-type#readme
-│  ├─ get-stream@6.0.1
-│  │  ├─ URL: https://github.com/sindresorhus/get-stream.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ get-symbol-description@1.0.0
-│  │  ├─ URL: git+https://github.com/inspect-js/get-symbol-description.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/get-symbol-description#readme
-│  ├─ global-modules@2.0.0
-│  │  ├─ URL: https://github.com/jonschlinkert/global-modules.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/jonschlinkert/global-modules
-│  ├─ global-prefix@3.0.0
-│  │  ├─ URL: https://github.com/jonschlinkert/global-prefix.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/jonschlinkert/global-prefix
-│  ├─ globals@11.12.0
-│  │  ├─ URL: https://github.com/sindresorhus/globals.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ globals@13.20.0
-│  │  ├─ URL: https://github.com/sindresorhus/globals.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ globalthis@1.0.3
-│  │  ├─ URL: git://github.com/ljharb/System.global.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ globby@11.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/globby.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ gopd@1.0.1
-│  │  ├─ URL: git+https://github.com/ljharb/gopd.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/ljharb/gopd#readme
-│  ├─ grapheme-splitter@1.0.4
-│  │  ├─ URL: https://github.com/orling/grapheme-splitter.git
-│  │  ├─ VendorName: Orlin Georgiev
-│  │  └─ VendorUrl: https://github.com/orling/grapheme-splitter
-│  ├─ gzip-size@6.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/gzip-size.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ hammerjs@2.0.8
-│  │  ├─ URL: git://github.com/hammerjs/hammer.js.git
-│  │  ├─ VendorName: Jorik Tangelder
-│  │  └─ VendorUrl: http://hammerjs.github.io/
-│  ├─ handle-thing@2.0.1
-│  │  ├─ URL: git+ssh://git@github.com/indutny/handle-thing.git
-│  │  ├─ VendorName: Fedor Indutny
-│  │  └─ VendorUrl: https://github.com/spdy-http2/handle-thing#readme
-│  ├─ has-bigints@1.0.2
-│  │  ├─ URL: git+https://github.com/ljharb/has-bigints.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/ljharb/has-bigints#readme
-│  ├─ has-flag@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/has-flag.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ has-flag@4.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/has-flag.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ has-property-descriptors@1.0.0
-│  │  ├─ URL: git+https://github.com/inspect-js/has-property-descriptors.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/has-property-descriptors#readme
-│  ├─ has-proto@1.0.1
-│  │  ├─ URL: git+https://github.com/inspect-js/has-proto.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/has-proto#readme
-│  ├─ has-symbols@1.0.3
-│  │  ├─ URL: git://github.com/inspect-js/has-symbols.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/ljharb/has-symbols#readme
-│  ├─ has-tostringtag@1.0.0
-│  │  ├─ URL: git+https://github.com/inspect-js/has-tostringtag.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/has-tostringtag#readme
-│  ├─ has@1.0.3
-│  │  ├─ URL: git://github.com/tarruda/has.git
-│  │  ├─ VendorName: Thiago de Arruda
-│  │  └─ VendorUrl: https://github.com/tarruda/has
-│  ├─ he@1.2.0
-│  │  ├─ URL: https://github.com/mathiasbynens/he.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://mths.be/he
-│  ├─ history@4.10.1
-│  │  ├─ URL: https://github.com/ReactTraining/history.git
-│  │  └─ VendorName: Michael Jackson
-│  ├─ hoopy@0.1.4
-│  │  ├─ URL: git+https://gitlab.com/philbooth/hoopy.git
-│  │  ├─ VendorName: Phil Booth
-│  │  └─ VendorUrl: https://gitlab.com/philbooth/hoopy#readme
-│  ├─ hpack.js@2.1.6
-│  │  ├─ URL: git+ssh://git@github.com/indutny/hpack.js.git
-│  │  ├─ VendorName: Fedor Indutny
-│  │  └─ VendorUrl: https://github.com/indutny/hpack.js#readme
-│  ├─ html-encoding-sniffer@2.0.1
-│  │  ├─ URL: https://github.com/jsdom/html-encoding-sniffer.git
-│  │  ├─ VendorName: Domenic Denicola
-│  │  └─ VendorUrl: https://domenic.me/
-│  ├─ html-entities@2.3.3
-│  │  ├─ URL: https://github.com/mdevils/html-entities.git
-│  │  └─ VendorName: Marat Dulin
-│  ├─ html-escaper@2.0.2
-│  │  ├─ URL: https://github.com/WebReflection/html-escaper.git
-│  │  ├─ VendorName: Andrea Giammarchi
-│  │  └─ VendorUrl: https://github.com/WebReflection/html-escaper
-│  ├─ html-minifier-terser@6.1.0
-│  │  ├─ URL: git+https://github.com/terser/html-minifier-terser.git
-│  │  ├─ VendorName: Daniel Ruf
-│  │  └─ VendorUrl: https://terser.org/html-minifier-terser/
-│  ├─ html-parse-stringify@3.0.1
-│  │  ├─ URL: https://github.com/henrikjoreteg/html-parse-stringify
-│  │  ├─ VendorName: Henrik Joreteg
-│  │  └─ VendorUrl: https://github.com/henrikjoreteg/html-parse-stringify
-│  ├─ html-webpack-plugin@5.5.0
-│  │  ├─ URL: https://github.com/jantimon/html-webpack-plugin.git
-│  │  ├─ VendorName: Jan Nicklas
-│  │  └─ VendorUrl: https://github.com/jantimon/html-webpack-plugin
-│  ├─ htmlparser2@6.1.0
-│  │  ├─ URL: git://github.com/fb55/htmlparser2.git
-│  │  └─ VendorName: Felix Boehm
-│  ├─ http-deceiver@1.2.7
-│  │  ├─ URL: git+ssh://git@github.com/indutny/http-deceiver.git
-│  │  ├─ VendorName: Fedor Indutny
-│  │  └─ VendorUrl: https://github.com/indutny/http-deceiver#readme
-│  ├─ http-errors@1.6.3
-│  │  ├─ URL: https://github.com/jshttp/http-errors.git
-│  │  ├─ VendorName: Jonathan Ong
-│  │  └─ VendorUrl: http://jongleberry.com
-│  ├─ http-errors@2.0.0
-│  │  ├─ URL: https://github.com/jshttp/http-errors.git
-│  │  ├─ VendorName: Jonathan Ong
-│  │  └─ VendorUrl: http://jongleberry.com
-│  ├─ http-parser-js@0.5.8
-│  │  ├─ URL: git://github.com/creationix/http-parser-js.git
-│  │  ├─ VendorName: Tim Caswell
-│  │  └─ VendorUrl: https://github.com/creationix
-│  ├─ http-proxy-agent@4.0.1
-│  │  ├─ URL: git://github.com/TooTallNate/node-http-proxy-agent.git
-│  │  ├─ VendorName: Nathan Rajlich
-│  │  └─ VendorUrl: http://n8.io/
-│  ├─ http-proxy-middleware@2.0.6
-│  │  ├─ URL: https://github.com/chimurai/http-proxy-middleware.git
-│  │  ├─ VendorName: Steven Chim
-│  │  └─ VendorUrl: https://github.com/chimurai/http-proxy-middleware#readme
-│  ├─ http-proxy@1.18.1
-│  │  ├─ URL: https://github.com/http-party/node-http-proxy.git
-│  │  └─ VendorName: Charlie Robbins
-│  ├─ https-proxy-agent@5.0.1
-│  │  ├─ URL: git://github.com/TooTallNate/node-https-proxy-agent.git
-│  │  ├─ VendorName: Nathan Rajlich
-│  │  └─ VendorUrl: http://n8.io/
-│  ├─ i18next-browser-languagedetector@6.1.8
-│  │  ├─ URL: https://github.com/i18next/i18next-browser-languageDetector.git
-│  │  ├─ VendorName: Jan Mühlemann
-│  │  └─ VendorUrl: https://github.com/i18next/i18next-browser-languageDetector
-│  ├─ i18next@21.10.0
-│  │  ├─ URL: https://github.com/i18next/i18next.git
-│  │  ├─ VendorName: Jan Mühlemann
-│  │  └─ VendorUrl: https://www.i18next.com/
-│  ├─ iconv-lite@0.4.24
-│  │  ├─ URL: git://github.com/ashtuchkin/iconv-lite.git
-│  │  ├─ VendorName: Alexander Shtuchkin
-│  │  └─ VendorUrl: https://github.com/ashtuchkin/iconv-lite
-│  ├─ iconv-lite@0.6.3
-│  │  ├─ URL: git://github.com/ashtuchkin/iconv-lite.git
-│  │  ├─ VendorName: Alexander Shtuchkin
-│  │  └─ VendorUrl: https://github.com/ashtuchkin/iconv-lite
-│  ├─ identity-obj-proxy@3.0.0
-│  │  ├─ URL: git+https://github.com/keyanzhang/identity-obj-proxy.git
-│  │  ├─ VendorName: Keyan Zhang
-│  │  └─ VendorUrl: https://github.com/keyanzhang/identity-obj-proxy#readme
-│  ├─ ignore@4.0.6
-│  │  ├─ URL: git@github.com:kaelzhang/node-ignore.git
-│  │  └─ VendorName: kael
-│  ├─ ignore@5.2.4
-│  │  ├─ URL: git@github.com:kaelzhang/node-ignore.git
-│  │  └─ VendorName: kael
-│  ├─ immer@9.0.19
-│  │  ├─ URL: https://github.com/immerjs/immer.git
-│  │  ├─ VendorName: Michel Weststrate
-│  │  └─ VendorUrl: https://github.com/immerjs/immer#readme
-│  ├─ import-fresh@3.3.0
-│  │  ├─ URL: https://github.com/sindresorhus/import-fresh.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ import-local@3.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/import-local.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ imurmurhash@0.1.4
-│  │  ├─ URL: https://github.com/jensyt/imurmurhash-js
-│  │  ├─ VendorName: Jens Taylor
-│  │  └─ VendorUrl: https://github.com/jensyt/imurmurhash-js
-│  ├─ indent-string@4.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/indent-string.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ internal-slot@1.0.4
-│  │  ├─ URL: git+https://github.com/ljharb/internal-slot.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/ljharb/internal-slot#readme
-│  ├─ invariant@2.2.4
-│  │  ├─ URL: https://github.com/zertosh/invariant
-│  │  └─ VendorName: Andres Suarez
-│  ├─ ipaddr.js@1.9.1
-│  │  ├─ URL: git://github.com/whitequark/ipaddr.js
-│  │  └─ VendorName: whitequark
-│  ├─ ipaddr.js@2.0.1
-│  │  ├─ URL: git://github.com/whitequark/ipaddr.js
-│  │  └─ VendorName: whitequark
-│  ├─ is-arguments@1.1.1
-│  │  ├─ URL: git://github.com/inspect-js/is-arguments.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/is-arguments
-│  ├─ is-array-buffer@3.0.1
-│  │  ├─ URL: git+https://github.com/inspect-js/is-array-buffer.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/is-array-buffer#readme
-│  ├─ is-arrayish@0.2.1
-│  │  ├─ URL: https://github.com/qix-/node-is-arrayish.git
-│  │  ├─ VendorName: Qix
-│  │  └─ VendorUrl: http://github.com/qix-
-│  ├─ is-bigint@1.0.4
-│  │  ├─ URL: git+https://github.com/inspect-js/is-bigint.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/is-bigint#readme
-│  ├─ is-binary-path@2.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/is-binary-path.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ is-boolean-object@1.1.2
-│  │  ├─ URL: git://github.com/inspect-js/is-boolean-object.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ is-callable@1.2.7
-│  │  ├─ URL: git://github.com/inspect-js/is-callable.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: http://ljharb.codes
-│  ├─ is-core-module@2.11.0
-│  │  ├─ URL: git+https://github.com/inspect-js/is-core-module.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/is-core-module
-│  ├─ is-date-object@1.0.5
-│  │  ├─ URL: git://github.com/inspect-js/is-date-object.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ is-docker@2.2.1
-│  │  ├─ URL: https://github.com/sindresorhus/is-docker.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ is-extglob@2.1.1
-│  │  ├─ URL: https://github.com/jonschlinkert/is-extglob.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/jonschlinkert/is-extglob
-│  ├─ is-fullwidth-code-point@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/is-fullwidth-code-point.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ is-generator-fn@2.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/is-generator-fn.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ is-glob@4.0.3
-│  │  ├─ URL: https://github.com/micromatch/is-glob.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/micromatch/is-glob
-│  ├─ is-map@2.0.2
-│  │  ├─ URL: git+https://github.com/inspect-js/is-map.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/is-map#readme
-│  ├─ is-module@1.0.0
-│  │  ├─ URL: https://github.com/component/is-module.git
-│  │  ├─ VendorName: Jonathan Ong
-│  │  └─ VendorUrl: http://jongleberry.com
-│  ├─ is-negative-zero@2.0.2
-│  │  ├─ URL: git://github.com/inspect-js/is-negative-zero.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/is-negative-zero
-│  ├─ is-number-object@1.0.7
-│  │  ├─ URL: git://github.com/inspect-js/is-number-object.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/is-number-object#readme
-│  ├─ is-number@7.0.0
-│  │  ├─ URL: https://github.com/jonschlinkert/is-number.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/jonschlinkert/is-number
-│  ├─ is-obj@1.0.1
-│  │  ├─ URL: https://github.com/sindresorhus/is-obj.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ is-path-inside@3.0.3
-│  │  ├─ URL: https://github.com/sindresorhus/is-path-inside.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ is-plain-obj@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/is-plain-obj.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ is-potential-custom-element-name@1.0.1
-│  │  ├─ URL: https://github.com/mathiasbynens/is-potential-custom-element-name.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://github.com/mathiasbynens/is-potential-custom-element-name
-│  ├─ is-regex@1.1.4
-│  │  ├─ URL: git://github.com/inspect-js/is-regex.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/is-regex
-│  ├─ is-regexp@1.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/is-regexp.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: http://sindresorhus.com
-│  ├─ is-root@2.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/is-root.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ is-set@2.0.2
-│  │  ├─ URL: git+https://github.com/inspect-js/is-set.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/is-set#readme
-│  ├─ is-shared-array-buffer@1.0.2
-│  │  ├─ URL: git+https://github.com/inspect-js/is-shared-array-buffer.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/is-shared-array-buffer#readme
-│  ├─ is-stream@2.0.1
-│  │  ├─ URL: https://github.com/sindresorhus/is-stream.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ is-string@1.0.7
-│  │  ├─ URL: git://github.com/ljharb/is-string.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ is-symbol@1.0.4
-│  │  ├─ URL: git://github.com/inspect-js/is-symbol.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ is-typed-array@1.1.10
-│  │  ├─ URL: git://github.com/inspect-js/is-typed-array.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: http://ljharb.codes
-│  ├─ is-typedarray@1.0.0
-│  │  ├─ URL: git://github.com/hughsk/is-typedarray.git
-│  │  ├─ VendorName: Hugh Kennedy
-│  │  └─ VendorUrl: https://github.com/hughsk/is-typedarray
-│  ├─ is-weakmap@2.0.1
-│  │  ├─ URL: git+https://github.com/inspect-js/is-weakmap.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/is-weakmap#readme
-│  ├─ is-weakref@1.0.2
-│  │  ├─ URL: git+https://github.com/inspect-js/is-weakref.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/is-weakref#readme
-│  ├─ is-weakset@2.0.2
-│  │  ├─ URL: git+https://github.com/inspect-js/is-weakset.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/is-weakset#readme
-│  ├─ is-wsl@2.2.0
-│  │  ├─ URL: https://github.com/sindresorhus/is-wsl.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ isarray@0.0.1
-│  │  ├─ URL: git://github.com/juliangruber/isarray.git
-│  │  ├─ VendorName: Julian Gruber
-│  │  └─ VendorUrl: https://github.com/juliangruber/isarray
-│  ├─ isarray@1.0.0
-│  │  ├─ URL: git://github.com/juliangruber/isarray.git
-│  │  ├─ VendorName: Julian Gruber
-│  │  └─ VendorUrl: https://github.com/juliangruber/isarray
-│  ├─ isarray@2.0.5
-│  │  ├─ URL: git://github.com/juliangruber/isarray.git
-│  │  ├─ VendorName: Julian Gruber
-│  │  └─ VendorUrl: https://github.com/juliangruber/isarray
-│  ├─ jest-changed-files@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-circus@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-cli@27.5.1
-│  │  ├─ URL: https://github.com/facebook/jest
-│  │  └─ VendorUrl: https://jestjs.io/
-│  ├─ jest-config@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-diff@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-diff@29.4.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-docblock@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-each@27.5.1
-│  │  ├─ URL: https://github.com/facebook/jest.git
-│  │  ├─ VendorName: Matt Phillips
-│  │  └─ VendorUrl: mattphillips
-│  ├─ jest-environment-jsdom@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-environment-node@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-get-type@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-get-type@29.2.0
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-haste-map@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-jasmine2@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-leak-detector@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-matcher-utils@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-matcher-utils@29.4.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-message-util@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-message-util@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-message-util@29.4.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-mock@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-pnp-resolver@1.2.3
-│  │  ├─ URL: https://github.com/arcanis/jest-pnp-resolver.git
-│  │  └─ VendorUrl: https://github.com/arcanis/jest-pnp-resolver
-│  ├─ jest-regex-util@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-regex-util@28.0.2
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-resolve-dependencies@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-resolve@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-runner@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-runtime@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-serializer@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-snapshot@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-util@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-util@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-util@29.4.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-validate@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-watch-typeahead@1.1.0
-│  │  ├─ URL: https://github.com/jest-community/jest-watch-typeahead.git
-│  │  ├─ VendorName: Rogelio Guzman
-│  │  └─ VendorUrl: https://github.com/jest-community/jest-watch-typeahead
-│  ├─ jest-watcher@27.5.1
-│  │  ├─ URL: https://github.com/facebook/jest
-│  │  └─ VendorUrl: https://jestjs.io/
-│  ├─ jest-watcher@28.1.3
-│  │  ├─ URL: https://github.com/facebook/jest.git
-│  │  └─ VendorUrl: https://jestjs.io/
-│  ├─ jest-worker@26.6.2
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-worker@27.5.1
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest-worker@28.1.3
-│  │  └─ URL: https://github.com/facebook/jest.git
-│  ├─ jest@27.5.1
-│  │  ├─ URL: https://github.com/facebook/jest
-│  │  └─ VendorUrl: https://jestjs.io/
-│  ├─ js-sdsl@4.3.0
-│  │  ├─ URL: https://github.com/js-sdsl/js-sdsl.git
-│  │  ├─ VendorName: ZLY201
-│  │  └─ VendorUrl: https://js-sdsl.org/
-│  ├─ js-sha256@0.9.0
-│  │  ├─ URL: https://github.com/emn178/js-sha256.git
-│  │  ├─ VendorName: Chen, Yi-Cyuan
-│  │  └─ VendorUrl: https://github.com/emn178/js-sha256
-│  ├─ js-tokens@4.0.0
-│  │  ├─ URL: https://github.com/lydell/js-tokens.git
-│  │  └─ VendorName: Simon Lydell
-│  ├─ js-yaml@3.14.1
-│  │  ├─ URL: https://github.com/nodeca/js-yaml.git
-│  │  ├─ VendorName: Vladimir Zapparov
-│  │  └─ VendorUrl: https://github.com/nodeca/js-yaml
-│  ├─ js-yaml@4.1.0
-│  │  ├─ URL: https://github.com/nodeca/js-yaml.git
-│  │  └─ VendorName: Vladimir Zapparov
-│  ├─ jsdom@16.7.0
-│  │  └─ URL: https://github.com/jsdom/jsdom.git
-│  ├─ jsesc@0.5.0
-│  │  ├─ URL: https://github.com/mathiasbynens/jsesc.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: http://mths.be/jsesc
-│  ├─ jsesc@2.5.2
-│  │  ├─ URL: https://github.com/mathiasbynens/jsesc.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://mths.be/jsesc
-│  ├─ json-parse-even-better-errors@2.3.1
-│  │  ├─ URL: https://github.com/npm/json-parse-even-better-errors
-│  │  └─ VendorName: Kat Marchán
-│  ├─ json-schema-traverse@0.4.1
-│  │  ├─ URL: git+https://github.com/epoberezkin/json-schema-traverse.git
-│  │  ├─ VendorName: Evgeny Poberezkin
-│  │  └─ VendorUrl: https://github.com/epoberezkin/json-schema-traverse#readme
-│  ├─ json-schema-traverse@1.0.0
-│  │  ├─ URL: git+https://github.com/epoberezkin/json-schema-traverse.git
-│  │  ├─ VendorName: Evgeny Poberezkin
-│  │  └─ VendorUrl: https://github.com/epoberezkin/json-schema-traverse#readme
-│  ├─ json-stable-stringify-without-jsonify@1.0.1
-│  │  ├─ URL: git://github.com/samn/json-stable-stringify.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: https://github.com/samn/json-stable-stringify
-│  ├─ json5@1.0.2
-│  │  ├─ URL: git+https://github.com/json5/json5.git
-│  │  ├─ VendorName: Aseem Kishore
-│  │  └─ VendorUrl: http://json5.org/
-│  ├─ json5@2.2.3
-│  │  ├─ URL: git+https://github.com/json5/json5.git
-│  │  ├─ VendorName: Aseem Kishore
-│  │  └─ VendorUrl: http://json5.org/
-│  ├─ jsonfile@6.1.0
-│  │  ├─ URL: git@github.com:jprichardson/node-jsonfile.git
-│  │  └─ VendorName: JP Richardson
-│  ├─ jsonpointer@5.0.1
-│  │  ├─ URL: https://github.com/janl/node-jsonpointer.git
-│  │  └─ VendorName: Jan Lehnardt
-│  ├─ jsx-ast-utils@3.3.3
-│  │  ├─ URL: https://github.com/jsx-eslint/jsx-ast-utils
-│  │  └─ VendorName: Ethan Cohen
-│  ├─ just-curry-it@3.2.1
-│  │  ├─ URL: https://github.com/angus-c/just
-│  │  └─ VendorName: Angus Croll
-│  ├─ kind-of@6.0.3
-│  │  ├─ URL: https://github.com/jonschlinkert/kind-of.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/jonschlinkert/kind-of
-│  ├─ kleur@3.0.3
-│  │  ├─ URL: https://github.com/lukeed/kleur.git
-│  │  ├─ VendorName: Luke Edwards
-│  │  └─ VendorUrl: lukeed.com
-│  ├─ klona@2.0.6
-│  │  ├─ URL: https://github.com/lukeed/klona.git
-│  │  ├─ VendorName: Luke Edwards
-│  │  └─ VendorUrl: https://lukeed.com
-│  ├─ language-tags@1.0.5
-│  │  ├─ URL: git://github.com/mattcg/language-tags.git
-│  │  ├─ VendorName: Matthew Caruana Galizia
-│  │  └─ VendorUrl: https://github.com/mattcg/language-tags
-│  ├─ leven@3.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/leven.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ levn@0.3.0
-│  │  ├─ URL: git://github.com/gkz/levn.git
-│  │  ├─ VendorName: George Zahariev
-│  │  └─ VendorUrl: https://github.com/gkz/levn
-│  ├─ levn@0.4.1
-│  │  ├─ URL: git://github.com/gkz/levn.git
-│  │  ├─ VendorName: George Zahariev
-│  │  └─ VendorUrl: https://github.com/gkz/levn
-│  ├─ lilconfig@2.0.6
-│  │  ├─ URL: https://github.com/antonk52/lilconfig
-│  │  └─ VendorName: antonk52
-│  ├─ lines-and-columns@1.2.4
-│  │  ├─ URL: https://github.com/eventualbuddha/lines-and-columns.git
-│  │  ├─ VendorName: Brian Donovan
-│  │  └─ VendorUrl: https://github.com/eventualbuddha/lines-and-columns#readme
-│  ├─ loader-runner@4.3.0
-│  │  ├─ URL: git+https://github.com/webpack/loader-runner.git
-│  │  ├─ VendorName: Tobias Koppers @sokra
-│  │  └─ VendorUrl: https://github.com/webpack/loader-runner#readme
-│  ├─ loader-utils@2.0.4
-│  │  ├─ URL: https://github.com/webpack/loader-utils.git
-│  │  └─ VendorName: Tobias Koppers @sokra
-│  ├─ loader-utils@3.2.1
-│  │  ├─ URL: https://github.com/webpack/loader-utils.git
-│  │  └─ VendorName: Tobias Koppers @sokra
-│  ├─ locate-path@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/locate-path.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ locate-path@5.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/locate-path.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ locate-path@6.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/locate-path.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ lodash.debounce@4.0.8
-│  │  ├─ URL: https://github.com/lodash/lodash.git
-│  │  ├─ VendorName: John-David Dalton
-│  │  └─ VendorUrl: https://lodash.com/
-│  ├─ lodash.memoize@4.1.2
-│  │  ├─ URL: https://github.com/lodash/lodash.git
-│  │  ├─ VendorName: John-David Dalton
-│  │  └─ VendorUrl: https://lodash.com/
-│  ├─ lodash.merge@4.6.2
-│  │  ├─ URL: https://github.com/lodash/lodash.git
-│  │  ├─ VendorName: John-David Dalton
-│  │  └─ VendorUrl: https://lodash.com/
-│  ├─ lodash.sortby@4.7.0
-│  │  ├─ URL: https://github.com/lodash/lodash.git
-│  │  ├─ VendorName: John-David Dalton
-│  │  └─ VendorUrl: https://lodash.com/
-│  ├─ lodash.truncate@4.4.2
-│  │  ├─ URL: https://github.com/lodash/lodash.git
-│  │  ├─ VendorName: John-David Dalton
-│  │  └─ VendorUrl: https://lodash.com/
-│  ├─ lodash.uniq@4.5.0
-│  │  ├─ URL: https://github.com/lodash/lodash.git
-│  │  ├─ VendorName: John-David Dalton
-│  │  └─ VendorUrl: https://lodash.com/
-│  ├─ lodash@4.17.21
-│  │  ├─ URL: https://github.com/lodash/lodash.git
-│  │  ├─ VendorName: John-David Dalton
-│  │  └─ VendorUrl: https://lodash.com/
-│  ├─ loose-envify@1.4.0
-│  │  ├─ URL: git://github.com/zertosh/loose-envify.git
-│  │  ├─ VendorName: Andres Suarez
-│  │  └─ VendorUrl: https://github.com/zertosh/loose-envify
-│  ├─ lower-case@2.0.2
-│  │  ├─ URL: git://github.com/blakeembrey/change-case.git
-│  │  ├─ VendorName: Blake Embrey
-│  │  └─ VendorUrl: https://github.com/blakeembrey/change-case/tree/master/packages/lower-case#readme
-│  ├─ magic-string@0.25.9
-│  │  ├─ URL: https://github.com/rich-harris/magic-string
-│  │  └─ VendorName: Rich Harris
-│  ├─ make-dir@3.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/make-dir.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ media-typer@0.3.0
-│  │  ├─ URL: https://github.com/jshttp/media-typer.git
-│  │  └─ VendorName: Douglas Christopher Wilson
-│  ├─ merge-descriptors@1.0.1
-│  │  ├─ URL: https://github.com/component/merge-descriptors.git
-│  │  ├─ VendorName: Jonathan Ong
-│  │  └─ VendorUrl: http://jongleberry.com
-│  ├─ merge-stream@2.0.0
-│  │  ├─ URL: https://github.com/grncdr/merge-stream.git
-│  │  └─ VendorName: Stephen Sugden
-│  ├─ merge2@1.4.1
-│  │  ├─ URL: git@github.com:teambition/merge2.git
-│  │  └─ VendorUrl: https://github.com/teambition/merge2
-│  ├─ methods@1.1.2
-│  │  └─ URL: https://github.com/jshttp/methods.git
-│  ├─ micromatch@4.0.5
-│  │  ├─ URL: https://github.com/micromatch/micromatch.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/micromatch/micromatch
-│  ├─ mime-db@1.52.0
-│  │  └─ URL: https://github.com/jshttp/mime-db.git
-│  ├─ mime-types@2.1.35
-│  │  └─ URL: https://github.com/jshttp/mime-types.git
-│  ├─ mime@1.6.0
-│  │  ├─ URL: https://github.com/broofa/node-mime
-│  │  ├─ VendorName: Robert Kieffer
-│  │  └─ VendorUrl: http://github.com/broofa
-│  ├─ mimic-fn@2.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/mimic-fn.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ min-indent@1.0.1
-│  │  ├─ URL: https://github.com/thejameskyle/min-indent
-│  │  ├─ VendorName: James Kyle
-│  │  └─ VendorUrl: thejameskyle.com
-│  ├─ mini-css-extract-plugin@2.7.2
-│  │  ├─ URL: https://github.com/webpack-contrib/mini-css-extract-plugin.git
-│  │  ├─ VendorName: Tobias Koppers @sokra
-│  │  └─ VendorUrl: https://github.com/webpack-contrib/mini-css-extract-plugin
-│  ├─ minimist@1.2.7
-│  │  ├─ URL: git://github.com/minimistjs/minimist.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: https://github.com/minimistjs/minimist
-│  ├─ mkdirp@0.5.6
-│  │  ├─ URL: https://github.com/substack/node-mkdirp.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: http://substack.net
-│  ├─ moment@2.29.4
-│  │  ├─ URL: https://github.com/moment/moment.git
-│  │  ├─ VendorName: Iskren Ivov Chernev
-│  │  └─ VendorUrl: https://momentjs.com/
-│  ├─ ms@2.0.0
-│  │  └─ URL: https://github.com/zeit/ms.git
-│  ├─ ms@2.1.2
-│  │  └─ URL: https://github.com/zeit/ms.git
-│  ├─ ms@2.1.3
-│  │  └─ URL: https://github.com/vercel/ms.git
-│  ├─ multicast-dns@7.2.5
-│  │  ├─ URL: https://github.com/mafintosh/multicast-dns.git
-│  │  ├─ VendorName: Mathias Buus
-│  │  └─ VendorUrl: https://github.com/mafintosh/multicast-dns
-│  ├─ nanoid@3.3.4
-│  │  ├─ URL: https://github.com/ai/nanoid.git
-│  │  └─ VendorName: Andrey Sitnik
-│  ├─ natural-compare-lite@1.4.0
-│  │  ├─ URL: git://github.com/litejs/natural-compare-lite.git
-│  │  ├─ VendorName: Lauri Rooden
-│  │  └─ VendorUrl: https://github.com/litejs/natural-compare-lite
-│  ├─ natural-compare@1.4.0
-│  │  ├─ URL: git://github.com/litejs/natural-compare-lite.git
-│  │  ├─ VendorName: Lauri Rooden
-│  │  └─ VendorUrl: https://github.com/litejs/natural-compare-lite
-│  ├─ negotiator@0.6.3
-│  │  └─ URL: https://github.com/jshttp/negotiator.git
-│  ├─ neo-async@2.6.2
-│  │  ├─ URL: git@github.com:suguru03/neo-async.git
-│  │  └─ VendorUrl: https://github.com/suguru03/neo-async
-│  ├─ no-case@3.0.4
-│  │  ├─ URL: git://github.com/blakeembrey/change-case.git
-│  │  ├─ VendorName: Blake Embrey
-│  │  └─ VendorUrl: https://github.com/blakeembrey/change-case/tree/master/packages/no-case#readme
-│  ├─ node-int64@0.4.0
-│  │  ├─ URL: https://github.com/broofa/node-int64
-│  │  └─ VendorName: Robert Kieffer
-│  ├─ node-releases@2.0.10
-│  │  ├─ URL: https://github.com/chicoxyzzy/node-releases.git
-│  │  └─ VendorName: Sergey Rubanov
-│  ├─ normalize-path@3.0.0
-│  │  ├─ URL: https://github.com/jonschlinkert/normalize-path.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/jonschlinkert/normalize-path
-│  ├─ normalize-range@0.1.2
-│  │  ├─ URL: https://github.com/jamestalmage/normalize-range.git
-│  │  ├─ VendorName: James Talmage
-│  │  └─ VendorUrl: github.com/jamestalmage
-│  ├─ normalize-url@6.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/normalize-url.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ npm-run-path@4.0.1
-│  │  ├─ URL: https://github.com/sindresorhus/npm-run-path.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ nwsapi@2.2.2
-│  │  ├─ URL: git://github.com/dperini/nwsapi.git
-│  │  ├─ VendorName: Diego Perini
-│  │  └─ VendorUrl: http://javascript.nwbox.com/nwsapi/
-│  ├─ object-assign@4.1.1
-│  │  ├─ URL: https://github.com/sindresorhus/object-assign.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ object-hash@3.0.0
-│  │  ├─ URL: https://github.com/puleos/object-hash
-│  │  ├─ VendorName: Scott Puleo
-│  │  └─ VendorUrl: https://github.com/puleos/object-hash
-│  ├─ object-inspect@1.12.3
-│  │  ├─ URL: git://github.com/inspect-js/object-inspect.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: https://github.com/inspect-js/object-inspect
-│  ├─ object-is@1.1.5
-│  │  ├─ URL: git://github.com/es-shims/object-is.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/es-shims/object-is
-│  ├─ object-keys@1.1.1
-│  │  ├─ URL: git://github.com/ljharb/object-keys.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: http://ljharb.codes
-│  ├─ object.assign@4.1.4
-│  │  ├─ URL: git://github.com/ljharb/object.assign.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ object.entries@1.1.6
-│  │  ├─ URL: git://github.com/es-shims/Object.entries.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ object.fromentries@2.0.6
-│  │  ├─ URL: git://github.com/es-shims/Object.fromEntries.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ object.getownpropertydescriptors@2.1.5
-│  │  ├─ URL: git://github.com/es-shims/object.getownpropertydescriptors.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ object.hasown@1.1.2
-│  │  ├─ URL: https://github.com/es-shims/Object.hasOwn.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/es-shims/Object.hasOwn
-│  ├─ object.values@1.1.6
-│  │  ├─ URL: git://github.com/es-shims/Object.values.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ obuf@1.1.2
-│  │  ├─ URL: git@github.com:indutny/offset-buffer
-│  │  ├─ VendorName: Fedor Indutny
-│  │  └─ VendorUrl: https://github.com/indutny/offset-buffer
-│  ├─ on-finished@2.4.1
-│  │  └─ URL: https://github.com/jshttp/on-finished.git
-│  ├─ on-headers@1.0.2
-│  │  ├─ URL: https://github.com/jshttp/on-headers.git
-│  │  └─ VendorName: Douglas Christopher Wilson
-│  ├─ onetime@5.1.2
-│  │  ├─ URL: https://github.com/sindresorhus/onetime.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ open@8.4.0
-│  │  ├─ URL: https://github.com/sindresorhus/open.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ optionator@0.8.3
-│  │  ├─ URL: git://github.com/gkz/optionator.git
-│  │  ├─ VendorName: George Zahariev
-│  │  └─ VendorUrl: https://github.com/gkz/optionator
-│  ├─ optionator@0.9.1
-│  │  ├─ URL: git://github.com/gkz/optionator.git
-│  │  ├─ VendorName: George Zahariev
-│  │  └─ VendorUrl: https://github.com/gkz/optionator
-│  ├─ p-limit@2.3.0
-│  │  ├─ URL: https://github.com/sindresorhus/p-limit.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ p-limit@3.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/p-limit.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ p-locate@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/p-locate.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ p-locate@4.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/p-locate.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ p-locate@5.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/p-locate.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ p-retry@4.6.2
-│  │  ├─ URL: https://github.com/sindresorhus/p-retry.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ p-try@2.2.0
-│  │  ├─ URL: https://github.com/sindresorhus/p-try.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ param-case@3.0.4
-│  │  ├─ URL: git://github.com/blakeembrey/change-case.git
-│  │  ├─ VendorName: Blake Embrey
-│  │  └─ VendorUrl: https://github.com/blakeembrey/change-case/tree/master/packages/param-case#readme
-│  ├─ parent-module@1.0.1
-│  │  ├─ URL: https://github.com/sindresorhus/parent-module.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ parse-json@5.2.0
-│  │  ├─ URL: https://github.com/sindresorhus/parse-json.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ parse5@6.0.1
-│  │  ├─ URL: git://github.com/inikulin/parse5.git
-│  │  ├─ VendorName: Ivan Nikulin
-│  │  └─ VendorUrl: https://github.com/inikulin/parse5
-│  ├─ parseurl@1.3.3
-│  │  └─ URL: https://github.com/pillarjs/parseurl.git
-│  ├─ pascal-case@3.1.2
-│  │  ├─ URL: git://github.com/blakeembrey/change-case.git
-│  │  ├─ VendorName: Blake Embrey
-│  │  └─ VendorUrl: https://github.com/blakeembrey/change-case/tree/master/packages/pascal-case#readme
-│  ├─ path-exists@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/path-exists.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ path-exists@4.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/path-exists.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ path-is-absolute@1.0.1
-│  │  ├─ URL: https://github.com/sindresorhus/path-is-absolute.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ path-key@3.1.1
-│  │  ├─ URL: https://github.com/sindresorhus/path-key.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ path-parse@1.0.7
-│  │  ├─ URL: https://github.com/jbgutierrez/path-parse.git
-│  │  ├─ VendorName: Javier Blanco
-│  │  └─ VendorUrl: https://github.com/jbgutierrez/path-parse#readme
-│  ├─ path-to-regexp@0.1.7
-│  │  └─ URL: https://github.com/component/path-to-regexp.git
-│  ├─ path-to-regexp@1.8.0
-│  │  └─ URL: https://github.com/pillarjs/path-to-regexp.git
-│  ├─ path-type@4.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/path-type.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ performance-now@2.1.0
-│  │  ├─ URL: git://github.com/braveg1rl/performance-now.git
-│  │  ├─ VendorName: Braveg1rl
-│  │  └─ VendorUrl: https://github.com/braveg1rl/performance-now
-│  ├─ picomatch@2.3.1
-│  │  ├─ URL: https://github.com/micromatch/picomatch.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/micromatch/picomatch
-│  ├─ pify@2.3.0
-│  │  ├─ URL: https://github.com/sindresorhus/pify.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ pirates@4.0.5
-│  │  ├─ URL: https://github.com/danez/pirates.git
-│  │  ├─ VendorName: Ari Porad
-│  │  └─ VendorUrl: https://github.com/danez/pirates#readme
-│  ├─ pkg-dir@4.2.0
-│  │  ├─ URL: https://github.com/sindresorhus/pkg-dir.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ pkg-up@3.1.0
-│  │  ├─ URL: https://github.com/sindresorhus/pkg-up.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ postcss-attribute-case-insensitive@5.0.2
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-attribute-case-insensitive#readme
-│  ├─ postcss-calc@8.2.4
-│  │  ├─ URL: https://github.com/postcss/postcss-calc.git
-│  │  └─ VendorName: Andy Jansson
-│  ├─ postcss-clamp@4.1.0
-│  │  ├─ URL: https://github.com/polemius/postcss-clamp.git
-│  │  └─ VendorName: Ivan Menshykov
-│  ├─ postcss-color-hex-alpha@8.0.4
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-color-hex-alpha#readme
-│  ├─ postcss-colormin@5.3.0
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-convert-values@5.1.3
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-custom-media@8.0.2
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-custom-media#readme
-│  ├─ postcss-custom-properties@12.1.11
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  ├─ VendorName: Jonathan Neal
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-custom-properties#readme
-│  ├─ postcss-custom-selectors@6.0.3
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-custom-selectors#readme
-│  ├─ postcss-discard-comments@5.1.2
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-discard-duplicates@5.1.0
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-discard-empty@5.1.1
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-discard-overridden@5.1.0
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Justineo
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-flexbugs-fixes@5.0.2
-│  │  ├─ URL: https://github.com/luisrudge/postcss-flexbugs-fixes.git
-│  │  └─ VendorName: Luis Rudge
-│  ├─ postcss-font-variant@5.0.0
-│  │  ├─ URL: https://github.com/postcss/postcss-font-variant.git
-│  │  └─ VendorName: Maxime Thirouin
-│  ├─ postcss-import@14.1.0
-│  │  ├─ URL: https://github.com/postcss/postcss-import.git
-│  │  └─ VendorName: Maxime Thirouin
-│  ├─ postcss-initial@4.0.1
-│  │  ├─ URL: https://github.com/maximkoretskiy/postcss-initial.git
-│  │  └─ VendorName: Maksim Koretskiy
-│  ├─ postcss-js@4.0.0
-│  │  ├─ URL: https://github.com/postcss/postcss-js.git
-│  │  └─ VendorName: Andrey Sitnik
-│  ├─ postcss-load-config@3.1.4
-│  │  ├─ URL: https://github.com/postcss/postcss-load-config.git
-│  │  └─ VendorName: Michael Ciniawky
-│  ├─ postcss-loader@6.2.1
-│  │  ├─ URL: https://github.com/webpack-contrib/postcss-loader.git
-│  │  ├─ VendorName: Andrey Sitnik
-│  │  └─ VendorUrl: https://github.com/webpack-contrib/postcss-loader
-│  ├─ postcss-media-minmax@5.0.0
-│  │  ├─ URL: https://github.com/postcss/postcss-media-minmax.git
-│  │  └─ VendorName: yisi
-│  ├─ postcss-merge-longhand@5.1.7
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-merge-rules@5.1.3
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-minify-font-values@5.1.0
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Bogdan Chadkin
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-minify-gradients@5.1.1
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-minify-params@5.1.4
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Bogdan Chadkin
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-minify-selectors@5.2.1
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-modules-local-by-default@4.0.0
-│  │  ├─ URL: https://github.com/css-modules/postcss-modules-local-by-default.git
-│  │  └─ VendorName: Mark Dalgleish
-│  ├─ postcss-nested@6.0.0
-│  │  ├─ URL: https://github.com/postcss/postcss-nested.git
-│  │  └─ VendorName: Andrey Sitnik
-│  ├─ postcss-normalize-charset@5.1.0
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Bogdan Chadkin
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-normalize-display-values@5.1.0
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-normalize-positions@5.1.1
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-normalize-repeat-style@5.1.1
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-normalize-string@5.1.0
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-normalize-timing-functions@5.1.0
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-normalize-unicode@5.1.1
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-normalize-url@5.1.0
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-normalize-whitespace@5.1.1
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-opacity-percentage@1.1.3
-│  │  ├─ URL: https://github.com/mrcgrtz/postcss-opacity-percentage.git
-│  │  ├─ VendorName: Marc Görtz
-│  │  └─ VendorUrl: https://marcgoertz.de/
-│  ├─ postcss-ordered-values@5.1.3
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-page-break@3.0.4
-│  │  ├─ URL: https://github.com/shrpne/postcss-page-break
-│  │  └─ VendorName: shrpne
-│  ├─ postcss-reduce-initial@5.1.1
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-reduce-transforms@5.1.0
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-replace-overflow-wrap@4.0.0
-│  │  ├─ URL: https://github.com/MattDiMu/postcss-replace-overflow-wrap.git
-│  │  ├─ VendorName: Matthias Müller
-│  │  └─ VendorUrl: https://github.com/MattDiMu/postcss-replace-overflow-wrap
-│  ├─ postcss-selector-not@6.0.1
-│  │  ├─ URL: https://github.com/csstools/postcss-plugins.git
-│  │  └─ VendorUrl: https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-selector-not#readme
-│  ├─ postcss-selector-parser@6.0.11
-│  │  ├─ URL: https://github.com/postcss/postcss-selector-parser.git
-│  │  └─ VendorUrl: https://github.com/postcss/postcss-selector-parser
-│  ├─ postcss-svgo@5.1.0
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-unique-selectors@5.1.1
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ postcss-value-parser@4.2.0
-│  │  ├─ URL: https://github.com/TrySound/postcss-value-parser.git
-│  │  ├─ VendorName: Bogdan Chadkin
-│  │  └─ VendorUrl: https://github.com/TrySound/postcss-value-parser
-│  ├─ postcss@7.0.39
-│  │  ├─ URL: https://github.com/postcss/postcss.git
-│  │  ├─ VendorName: Andrey Sitnik
-│  │  └─ VendorUrl: https://postcss.org/
-│  ├─ postcss@8.4.21
-│  │  ├─ URL: https://github.com/postcss/postcss.git
-│  │  ├─ VendorName: Andrey Sitnik
-│  │  └─ VendorUrl: https://postcss.org/
-│  ├─ prelude-ls@1.1.2
-│  │  ├─ URL: git://github.com/gkz/prelude-ls.git
-│  │  ├─ VendorName: George Zahariev
-│  │  └─ VendorUrl: http://preludels.com/
-│  ├─ prelude-ls@1.2.1
-│  │  ├─ URL: git://github.com/gkz/prelude-ls.git
-│  │  ├─ VendorName: George Zahariev
-│  │  └─ VendorUrl: http://preludels.com/
-│  ├─ prettier@2.6.2
-│  │  ├─ URL: https://github.com/prettier/prettier.git
-│  │  ├─ VendorName: James Long
-│  │  └─ VendorUrl: https://prettier.io/
-│  ├─ pretty-bytes@5.6.0
-│  │  ├─ URL: https://github.com/sindresorhus/pretty-bytes.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ pretty-error@4.0.0
-│  │  ├─ URL: https://github.com/AriaMinaei/pretty-error.git
-│  │  └─ VendorName: Aria Minaei
-│  ├─ pretty-format@27.5.1
-│  │  ├─ URL: https://github.com/facebook/jest.git
-│  │  └─ VendorName: James Kyle
-│  ├─ pretty-format@28.1.3
-│  │  ├─ URL: https://github.com/facebook/jest.git
-│  │  └─ VendorName: James Kyle
-│  ├─ pretty-format@29.4.1
-│  │  ├─ URL: https://github.com/facebook/jest.git
-│  │  └─ VendorName: James Kyle
-│  ├─ process-nextick-args@2.0.1
-│  │  ├─ URL: https://github.com/calvinmetcalf/process-nextick-args.git
-│  │  └─ VendorUrl: https://github.com/calvinmetcalf/process-nextick-args
-│  ├─ progress@2.0.3
-│  │  ├─ URL: git://github.com/visionmedia/node-progress
-│  │  └─ VendorName: TJ Holowaychuk
-│  ├─ promise@8.3.0
-│  │  ├─ URL: https://github.com/then/promise.git
-│  │  └─ VendorName: ForbesLindesay
-│  ├─ prompts@2.4.2
-│  │  ├─ URL: https://github.com/terkelg/prompts.git
-│  │  ├─ VendorName: Terkel Gjervig
-│  │  └─ VendorUrl: https://terkel.com
-│  ├─ prop-types-extra@1.1.1
-│  │  ├─ URL: git+https://github.com/react-bootstrap/prop-types-extra.git
-│  │  ├─ VendorName: Matthew L Smith
-│  │  └─ VendorUrl: https://github.com/react-bootstrap/prop-types-extra#readme
-│  ├─ prop-types@15.8.1
-│  │  ├─ URL: https://github.com/facebook/prop-types.git
-│  │  └─ VendorUrl: https://facebook.github.io/react/
-│  ├─ propagating-hammerjs@1.5.0
-│  │  ├─ URL: https://github.com/josdejong/propagating-hammerjs.git
-│  │  ├─ VendorName: Jos de Jong
-│  │  └─ VendorUrl: https://github.com/josdejong/propagating-hammerjs
-│  ├─ proxy-addr@2.0.7
-│  │  ├─ URL: https://github.com/jshttp/proxy-addr.git
-│  │  └─ VendorName: Douglas Christopher Wilson
-│  ├─ psl@1.9.0
-│  │  ├─ URL: git@github.com:lupomontero/psl.git
-│  │  ├─ VendorName: Lupo Montero
-│  │  └─ VendorUrl: https://lupomontero.com/
-│  ├─ punycode@2.3.0
-│  │  ├─ URL: https://github.com/mathiasbynens/punycode.js.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://mths.be/punycode
-│  ├─ q@1.5.1
-│  │  ├─ URL: git://github.com/kriskowal/q.git
-│  │  ├─ VendorName: Kris Kowal
-│  │  └─ VendorUrl: https://github.com/kriskowal/q
-│  ├─ querystringify@2.2.0
-│  │  ├─ URL: https://github.com/unshiftio/querystringify
-│  │  ├─ VendorName: Arnout Kazemier
-│  │  └─ VendorUrl: https://github.com/unshiftio/querystringify
-│  ├─ queue-microtask@1.2.3
-│  │  ├─ URL: git://github.com/feross/queue-microtask.git
-│  │  ├─ VendorName: Feross Aboukhadijeh
-│  │  └─ VendorUrl: https://github.com/feross/queue-microtask
-│  ├─ quick-lru@5.1.1
-│  │  ├─ URL: https://github.com/sindresorhus/quick-lru.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ raf@3.4.1
-│  │  ├─ URL: git://github.com/chrisdickinson/raf.git
-│  │  └─ VendorName: Chris Dickinson
-│  ├─ randombytes@2.1.0
-│  │  ├─ URL: git@github.com:crypto-browserify/randombytes.git
-│  │  └─ VendorUrl: https://github.com/crypto-browserify/randombytes
-│  ├─ range-parser@1.2.1
-│  │  ├─ URL: https://github.com/jshttp/range-parser.git
-│  │  ├─ VendorName: TJ Holowaychuk
-│  │  └─ VendorUrl: http://tjholowaychuk.com
-│  ├─ raw-body@2.5.1
-│  │  ├─ URL: https://github.com/stream-utils/raw-body.git
-│  │  ├─ VendorName: Jonathan Ong
-│  │  └─ VendorUrl: http://jongleberry.com
-│  ├─ react-app-polyfill@3.0.0
-│  │  └─ URL: https://github.com/facebook/create-react-app.git
-│  ├─ react-bootstrap@2.7.0
-│  │  ├─ URL: git+https://github.com/react-bootstrap/react-bootstrap.git
-│  │  ├─ VendorName: Stephen J. Collings
-│  │  └─ VendorUrl: https://react-bootstrap.github.io/
-│  ├─ react-datepicker@4.10.0
-│  │  ├─ URL: git://github.com/Hacker0x01/react-datepicker.git
-│  │  ├─ VendorName: HackerOne
-│  │  └─ VendorUrl: https://github.com/Hacker0x01/react-datepicker
-│  ├─ react-dev-utils@12.0.1
-│  │  └─ URL: https://github.com/facebook/create-react-app.git
-│  ├─ react-dom@18.2.0
-│  │  ├─ URL: https://github.com/facebook/react.git
-│  │  └─ VendorUrl: https://reactjs.org/
-│  ├─ react-drag-drop-files@2.3.8
-│  │  ├─ URL: https://github.com/KarimMokhtar/react-drag-drop-files
-│  │  ├─ VendorName: Karim
-│  │  └─ VendorUrl: https://github.com/KarimMokhtar/react-drag-drop-files
-│  ├─ react-dropzone-uploader@2.11.0
-│  │  ├─ URL: git://github.com/fortana-co/react-dropzone-uploader.git
-│  │  └─ VendorName: Kyle Bebak
-│  ├─ react-dropzone@11.7.1
-│  │  ├─ URL: https://github.com/react-dropzone/react-dropzone.git
-│  │  ├─ VendorName: Param Aggarwal
-│  │  └─ VendorUrl: https://github.com/react-dropzone/react-dropzone
-│  ├─ react-error-overlay@6.0.11
-│  │  ├─ URL: https://github.com/facebook/create-react-app.git
-│  │  └─ VendorName: Joe Haddad
-│  ├─ react-fast-compare@3.2.0
-│  │  ├─ URL: git+https://github.com/FormidableLabs/react-fast-compare.git
-│  │  ├─ VendorName: Chris Bolin
-│  │  └─ VendorUrl: https://github.com/FormidableLabs/react-fast-compare
-│  ├─ react-i18next@11.18.6
-│  │  ├─ URL: https://github.com/i18next/react-i18next.git
-│  │  ├─ VendorName: Jan Mühlemann
-│  │  └─ VendorUrl: https://github.com/i18next/react-i18next
-│  ├─ react-icons@4.7.1
-│  │  ├─ URL: git+ssh://git@github.com:react-icons/react-icons.git
-│  │  ├─ VendorName: Goran Gajic
-│  │  └─ VendorUrl: https://github.com/react-icons/react-icons#readme
-│  ├─ react-is@16.13.1
-│  │  ├─ URL: https://github.com/facebook/react.git
-│  │  └─ VendorUrl: https://reactjs.org/
-│  ├─ react-is@17.0.2
-│  │  ├─ URL: https://github.com/facebook/react.git
-│  │  └─ VendorUrl: https://reactjs.org/
-│  ├─ react-is@18.2.0
-│  │  ├─ URL: https://github.com/facebook/react.git
-│  │  └─ VendorUrl: https://reactjs.org/
-│  ├─ react-lifecycles-compat@3.0.4
-│  │  └─ URL: https://github.com/reactjs/react-lifecycles-compat.git
-│  ├─ react-onclickoutside@6.12.2
-│  │  ├─ URL: https://github.com/Pomax/react-onclickoutside.git
-│  │  └─ VendorUrl: https://github.com/Pomax/react-onclickoutside
-│  ├─ react-popper@2.3.0
-│  │  ├─ URL: https://github.com/popperjs/react-popper
-│  │  ├─ VendorName: Travis Arnold
-│  │  └─ VendorUrl: https://popper.js.org/react-popper
-│  ├─ react-redux@7.2.9
-│  │  ├─ URL: https://github.com/reduxjs/react-redux.git
-│  │  ├─ VendorName: Dan Abramov
-│  │  └─ VendorUrl: https://github.com/reduxjs/react-redux
-│  ├─ react-refresh@0.11.0
-│  │  ├─ URL: https://github.com/facebook/react.git
-│  │  └─ VendorUrl: https://reactjs.org/
-│  ├─ react-router-dom@5.3.4
-│  │  ├─ URL: https://github.com/remix-run/react-router.git
-│  │  ├─ VendorName: Remix Software
-│  │  └─ VendorUrl: https://reactrouter.com/
-│  ├─ react-router@5.3.4
-│  │  ├─ URL: https://github.com/remix-run/react-router.git
-│  │  ├─ VendorName: Remix Software
-│  │  └─ VendorUrl: https://reactrouter.com/
-│  ├─ react-scripts@5.0.1
-│  │  └─ URL: https://github.com/facebook/create-react-app.git
-│  ├─ react-search-input@0.11.3
-│  │  ├─ URL: https://github.com/enkidevs/react-search-input
-│  │  ├─ VendorName: Mathieu Dutour
-│  │  └─ VendorUrl: https://github.com/enkidevs/react-search-input
-│  ├─ react-toastify@8.2.0
-│  │  ├─ URL: git+https://github.com/fkhadra/react-toastify.git
-│  │  ├─ VendorName: Fadi Khadra
-│  │  └─ VendorUrl: https://github.com/fkhadra/react-toastify#readme
-│  ├─ react-tooltip@4.5.1
-│  │  ├─ URL: https://github.com/ReactTooltip/react-tooltip
-│  │  ├─ VendorName: ReactTooltip
-│  │  └─ VendorUrl: https://github.com/ReactTooltip/react-tooltip#readme
-│  ├─ react@18.2.0
-│  │  ├─ URL: https://github.com/facebook/react.git
-│  │  └─ VendorUrl: https://reactjs.org/
-│  ├─ read-cache@1.0.0
-│  │  ├─ URL: git+https://github.com/TrySound/read-cache.git
-│  │  ├─ VendorName: Bogdan Chadkin
-│  │  └─ VendorUrl: https://github.com/TrySound/read-cache#readme
-│  ├─ readable-stream@2.3.7
-│  │  └─ URL: git://github.com/nodejs/readable-stream
-│  ├─ readable-stream@3.6.0
-│  │  └─ URL: git://github.com/nodejs/readable-stream
-│  ├─ readdirp@3.6.0
-│  │  ├─ URL: git://github.com/paulmillr/readdirp.git
-│  │  ├─ VendorName: Thorsten Lorenz
-│  │  └─ VendorUrl: https://github.com/paulmillr/readdirp
-│  ├─ recursive-readdir@2.2.3
-│  │  ├─ URL: git://github.com/jergason/recursive-readdir.git
-│  │  ├─ VendorName: Jamison Dance
-│  │  └─ VendorUrl: http://jamison.dance.com/
-│  ├─ redent@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/redent.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ reduce-reducers@0.4.3
-│  │  ├─ URL: https://github.com/redux-utilities/reduce-reducers.git
-│  │  └─ VendorName: Andrew Clark
-│  ├─ redux-actions@2.6.5
-│  │  ├─ URL: https://github.com/redux-utilities/redux-actions.git
-│  │  ├─ VendorName: Andrew Clark
-│  │  └─ VendorUrl: https://github.com/redux-utilities/redux-actions
-│  ├─ redux-thunk@2.4.2
-│  │  ├─ URL: https://github.com/reduxjs/redux-thunk.git
-│  │  ├─ VendorName: Dan Abramov
-│  │  └─ VendorUrl: https://github.com/reduxjs/redux-thunk
-│  ├─ redux@4.2.1
-│  │  ├─ URL: https://github.com/reduxjs/redux.git
-│  │  └─ VendorUrl: http://redux.js.org/
-│  ├─ regenerate-unicode-properties@10.1.0
-│  │  ├─ URL: https://github.com/mathiasbynens/regenerate-unicode-properties.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://github.com/mathiasbynens/regenerate-unicode-properties
-│  ├─ regenerate@1.4.2
-│  │  ├─ URL: https://github.com/mathiasbynens/regenerate.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://mths.be/regenerate
-│  ├─ regenerator-runtime@0.13.11
-│  │  ├─ URL: https://github.com/facebook/regenerator/tree/main/packages/runtime
-│  │  └─ VendorName: Ben Newman
-│  ├─ regenerator-transform@0.15.1
-│  │  ├─ URL: https://github.com/facebook/regenerator/tree/main/packages/transform
-│  │  └─ VendorName: Ben Newman
-│  ├─ regex-parser@2.2.11
-│  │  ├─ URL: git@github.com:IonicaBizau/regex-parser.js.git
-│  │  ├─ VendorName: Ionică Bizău
-│  │  └─ VendorUrl: https://github.com/IonicaBizau/regex-parser.js
-│  ├─ regexp.prototype.flags@1.4.3
-│  │  ├─ URL: git://github.com/es-shims/RegExp.prototype.flags.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ regexpp@3.2.0
-│  │  ├─ URL: git+https://github.com/mysticatea/regexpp.git
-│  │  ├─ VendorName: Toru Nagashima
-│  │  └─ VendorUrl: https://github.com/mysticatea/regexpp#readme
-│  ├─ regexpu-core@5.2.2
-│  │  ├─ URL: https://github.com/mathiasbynens/regexpu-core.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://mths.be/regexpu
-│  ├─ regjsgen@0.7.1
-│  │  ├─ URL: https://github.com/bnjmnt4n/regjsgen.git
-│  │  ├─ VendorName: Benjamin Tan
-│  │  └─ VendorUrl: https://github.com/bnjmnt4n/regjsgen
-│  ├─ relateurl@0.2.7
-│  │  ├─ URL: git://github.com/stevenvachon/relateurl.git
-│  │  ├─ VendorName: Steven Vachon
-│  │  └─ VendorUrl: https://github.com/stevenvachon/relateurl
-│  ├─ renderkid@3.0.0
-│  │  ├─ URL: https://github.com/AriaMinaei/RenderKid.git
-│  │  └─ VendorName: Aria Minaei
-│  ├─ require-directory@2.1.1
-│  │  ├─ URL: git://github.com/troygoode/node-require-directory.git
-│  │  ├─ VendorName: Troy Goode
-│  │  └─ VendorUrl: https://github.com/troygoode/node-require-directory/
-│  ├─ require-from-string@2.0.2
-│  │  ├─ URL: https://github.com/floatdrop/require-from-string.git
-│  │  ├─ VendorName: Vsevolod Strukchinsky
-│  │  └─ VendorUrl: github.com/floatdrop
-│  ├─ requires-port@1.0.0
-│  │  ├─ URL: https://github.com/unshiftio/requires-port
-│  │  ├─ VendorName: Arnout Kazemier
-│  │  └─ VendorUrl: https://github.com/unshiftio/requires-port
-│  ├─ reselect@4.1.7
-│  │  └─ URL: https://github.com/reduxjs/reselect.git
-│  ├─ resolve-cwd@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/resolve-cwd.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ resolve-from@4.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/resolve-from.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ resolve-from@5.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/resolve-from.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ resolve-pathname@3.0.0
-│  │  ├─ URL: https://github.com/mjackson/resolve-pathname.git
-│  │  └─ VendorName: Michael Jackson
-│  ├─ resolve-url-loader@4.0.0
-│  │  ├─ URL: git+https://github.com/bholloway/resolve-url-loader.git
-│  │  ├─ VendorName: bholloway
-│  │  └─ VendorUrl: https://github.com/bholloway/resolve-url-loader/tree/v4-maintenance/packages/resolve-url-loader
-│  ├─ resolve.exports@1.1.1
-│  │  ├─ URL: https://github.com/lukeed/resolve.exports.git
-│  │  ├─ VendorName: Luke Edwards
-│  │  └─ VendorUrl: https://lukeed.com
-│  ├─ resolve@1.22.1
-│  │  ├─ URL: git://github.com/browserify/resolve.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: http://substack.net
-│  ├─ resolve@2.0.0-next.4
-│  │  ├─ URL: git://github.com/browserify/resolve.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: http://substack.net
-│  ├─ retry@0.13.1
-│  │  ├─ URL: git://github.com/tim-kos/node-retry.git
-│  │  ├─ VendorName: Tim Koschützki
-│  │  └─ VendorUrl: https://github.com/tim-kos/node-retry
-│  ├─ reusify@1.0.4
-│  │  ├─ URL: git+https://github.com/mcollina/reusify.git
-│  │  ├─ VendorName: Matteo Collina
-│  │  └─ VendorUrl: https://github.com/mcollina/reusify#readme
-│  ├─ rollup-plugin-terser@7.0.2
-│  │  ├─ URL: git+https://github.com/TrySound/rollup-plugin-terser.git
-│  │  └─ VendorName: Bogdan Chadkin
-│  ├─ rollup@2.79.1
-│  │  ├─ URL: https://github.com/rollup/rollup.git
-│  │  ├─ VendorName: Rich Harris
-│  │  └─ VendorUrl: https://rollupjs.org/
-│  ├─ run-parallel@1.2.0
-│  │  ├─ URL: git://github.com/feross/run-parallel.git
-│  │  ├─ VendorName: Feross Aboukhadijeh
-│  │  └─ VendorUrl: https://github.com/feross/run-parallel
-│  ├─ safe-buffer@5.1.2
-│  │  ├─ URL: git://github.com/feross/safe-buffer.git
-│  │  ├─ VendorName: Feross Aboukhadijeh
-│  │  └─ VendorUrl: https://github.com/feross/safe-buffer
-│  ├─ safe-buffer@5.2.1
-│  │  ├─ URL: git://github.com/feross/safe-buffer.git
-│  │  ├─ VendorName: Feross Aboukhadijeh
-│  │  └─ VendorUrl: https://github.com/feross/safe-buffer
-│  ├─ safe-regex-test@1.0.0
-│  │  ├─ URL: git+https://github.com/ljharb/safe-regex-test.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/ljharb/safe-regex-test#readme
-│  ├─ safer-buffer@2.1.2
-│  │  ├─ URL: git+https://github.com/ChALkeR/safer-buffer.git
-│  │  ├─ VendorName: Nikita Skovoroda
-│  │  └─ VendorUrl: https://github.com/ChALkeR
-│  ├─ sass-loader@12.6.0
-│  │  ├─ URL: https://github.com/webpack-contrib/sass-loader.git
-│  │  ├─ VendorName: J. Tangelder
-│  │  └─ VendorUrl: https://github.com/webpack-contrib/sass-loader
-│  ├─ scheduler@0.23.0
-│  │  ├─ URL: https://github.com/facebook/react.git
-│  │  └─ VendorUrl: https://reactjs.org/
-│  ├─ schema-utils@2.7.0
-│  │  ├─ URL: https://github.com/webpack/schema-utils.git
-│  │  ├─ VendorName: webpack Contrib
-│  │  └─ VendorUrl: https://github.com/webpack/schema-utils
-│  ├─ schema-utils@2.7.1
-│  │  ├─ URL: https://github.com/webpack/schema-utils.git
-│  │  ├─ VendorName: webpack Contrib
-│  │  └─ VendorUrl: https://github.com/webpack/schema-utils
-│  ├─ schema-utils@3.1.1
-│  │  ├─ URL: https://github.com/webpack/schema-utils.git
-│  │  ├─ VendorName: webpack Contrib
-│  │  └─ VendorUrl: https://github.com/webpack/schema-utils
-│  ├─ schema-utils@4.0.0
-│  │  ├─ URL: https://github.com/webpack/schema-utils.git
-│  │  ├─ VendorName: webpack Contrib
-│  │  └─ VendorUrl: https://github.com/webpack/schema-utils
-│  ├─ select-hose@2.0.0
-│  │  ├─ URL: git+ssh://git@github.com/indutny/select-hose.git
-│  │  ├─ VendorName: Fedor Indutny
-│  │  └─ VendorUrl: https://github.com/indutny/select-hose#readme
-│  ├─ selfsigned@2.1.1
-│  │  ├─ URL: git://github.com/jfromaniello/selfsigned.git
-│  │  ├─ VendorName: José F. Romaniello
-│  │  └─ VendorUrl: http://joseoncode.com
-│  ├─ send@0.18.0
-│  │  ├─ URL: https://github.com/pillarjs/send.git
-│  │  └─ VendorName: TJ Holowaychuk
-│  ├─ serve-index@1.9.1
-│  │  ├─ URL: https://github.com/expressjs/serve-index.git
-│  │  └─ VendorName: Douglas Christopher Wilson
-│  ├─ serve-static@1.15.0
-│  │  ├─ URL: https://github.com/expressjs/serve-static.git
-│  │  └─ VendorName: Douglas Christopher Wilson
-│  ├─ shallowequal@1.1.0
-│  │  ├─ URL: https://github.com/dashed/shallowequal.git
-│  │  ├─ VendorName: Alberto Leal
-│  │  └─ VendorUrl: github.com/dashed
-│  ├─ shebang-command@2.0.0
-│  │  ├─ URL: https://github.com/kevva/shebang-command.git
-│  │  ├─ VendorName: Kevin Mårtensson
-│  │  └─ VendorUrl: github.com/kevva
-│  ├─ shebang-regex@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/shebang-regex.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ shell-quote@1.8.0
-│  │  ├─ URL: http://github.com/ljharb/shell-quote.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: https://github.com/ljharb/shell-quote
-│  ├─ side-channel@1.0.4
-│  │  ├─ URL: git+https://github.com/ljharb/side-channel.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/ljharb/side-channel#readme
-│  ├─ sisteransi@1.0.5
-│  │  ├─ URL: https://github.com/terkelg/sisteransi
-│  │  ├─ VendorName: Terkel Gjervig
-│  │  └─ VendorUrl: https://terkel.com
-│  ├─ slash@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/slash.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ slash@4.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/slash.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ slice-ansi@4.0.0
-│  │  └─ URL: https://github.com/chalk/slice-ansi.git
-│  ├─ sockjs@0.3.24
-│  │  ├─ URL: https://github.com/sockjs/sockjs-node.git
-│  │  ├─ VendorName: Marek Majkowski
-│  │  └─ VendorUrl: https://github.com/sockjs/sockjs-node
-│  ├─ source-list-map@2.0.1
-│  │  ├─ URL: https://github.com/webpack/source-list-map.git
-│  │  ├─ VendorName: Tobias Koppers @sokra
-│  │  └─ VendorUrl: https://github.com/webpack/source-list-map
-│  ├─ source-map-loader@3.0.2
-│  │  ├─ URL: https://github.com/webpack-contrib/source-map-loader.git
-│  │  ├─ VendorName: Tobias Koppers @sokra
-│  │  └─ VendorUrl: https://github.com/webpack-contrib/source-map-loader
-│  ├─ source-map-support@0.5.21
-│  │  └─ URL: https://github.com/evanw/node-source-map-support
-│  ├─ sourcemap-codec@1.4.8
-│  │  ├─ URL: https://github.com/Rich-Harris/sourcemap-codec
-│  │  ├─ VendorName: Rich Harris
-│  │  └─ VendorUrl: https://github.com/Rich-Harris/sourcemap-codec
-│  ├─ spdy-transport@3.0.0
-│  │  ├─ URL: git://github.com/spdy-http2/spdy-transport.git
-│  │  ├─ VendorName: Fedor Indutny
-│  │  └─ VendorUrl: https://github.com/spdy-http2/spdy-transport
-│  ├─ spdy@4.0.2
-│  │  ├─ URL: git://github.com/indutny/node-spdy.git
-│  │  ├─ VendorName: Fedor Indutny
-│  │  └─ VendorUrl: https://github.com/indutny/node-spdy
-│  ├─ stable@0.1.8
-│  │  ├─ URL: https://github.com/Two-Screen/stable.git
-│  │  └─ VendorName: Angry Bytes
-│  ├─ stack-utils@2.0.6
-│  │  ├─ URL: https://github.com/tapjs/stack-utils.git
-│  │  ├─ VendorName: James Talmage
-│  │  └─ VendorUrl: github.com/jamestalmage
-│  ├─ stackframe@1.3.4
-│  │  ├─ URL: git://github.com/stacktracejs/stackframe.git
-│  │  └─ VendorUrl: https://www.stacktracejs.com/
-│  ├─ statuses@1.5.0
-│  │  └─ URL: https://github.com/jshttp/statuses.git
-│  ├─ statuses@2.0.1
-│  │  └─ URL: https://github.com/jshttp/statuses.git
-│  ├─ stop-iteration-iterator@1.0.0
-│  │  ├─ URL: git+https://github.com/ljharb/stop-iteration-iterator.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/ljharb/stop-iteration-iterator#readme
-│  ├─ string_decoder@1.1.1
-│  │  ├─ URL: git://github.com/nodejs/string_decoder.git
-│  │  └─ VendorUrl: https://github.com/nodejs/string_decoder
-│  ├─ string_decoder@1.3.0
-│  │  ├─ URL: git://github.com/nodejs/string_decoder.git
-│  │  └─ VendorUrl: https://github.com/nodejs/string_decoder
-│  ├─ string-length@4.0.2
-│  │  ├─ URL: https://github.com/sindresorhus/string-length.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ string-length@5.0.1
-│  │  ├─ URL: https://github.com/sindresorhus/string-length.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ string-natural-compare@3.0.1
-│  │  ├─ URL: https://github.com/nwoltman/string-natural-compare.git
-│  │  ├─ VendorName: Nathan Woltman
-│  │  └─ VendorUrl: https://github.com/nwoltman/string-natural-compare
-│  ├─ string-width@4.2.3
-│  │  ├─ URL: https://github.com/sindresorhus/string-width.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ string.prototype.matchall@4.0.8
-│  │  ├─ URL: git+https://github.com/es-shims/String.prototype.matchAll.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/es-shims/String.prototype.matchAll#readme
-│  ├─ string.prototype.trimend@1.0.6
-│  │  ├─ URL: git://github.com/es-shims/String.prototype.trimEnd.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ string.prototype.trimstart@1.0.6
-│  │  ├─ URL: git://github.com/es-shims/String.prototype.trimStart.git
-│  │  └─ VendorName: Jordan Harband
-│  ├─ strip-ansi@6.0.1
-│  │  ├─ URL: https://github.com/chalk/strip-ansi.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ strip-ansi@7.0.1
-│  │  ├─ URL: https://github.com/chalk/strip-ansi.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ strip-bom@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/strip-bom.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ strip-bom@4.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/strip-bom.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ strip-comments@2.0.1
-│  │  ├─ URL: https://github.com/jonschlinkert/strip-comments.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/jonschlinkert/strip-comments
-│  ├─ strip-final-newline@2.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/strip-final-newline.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ strip-indent@3.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/strip-indent.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ strip-json-comments@3.1.1
-│  │  ├─ URL: https://github.com/sindresorhus/strip-json-comments.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ style-loader@3.3.1
-│  │  ├─ URL: https://github.com/webpack-contrib/style-loader.git
-│  │  ├─ VendorName: Tobias Koppers @sokra
-│  │  └─ VendorUrl: https://github.com/webpack-contrib/style-loader
-│  ├─ styled-components@5.3.6
-│  │  ├─ URL: git+https://github.com/styled-components/styled-components.git
-│  │  ├─ VendorName: Glen Maddern
-│  │  └─ VendorUrl: https://styled-components.com/
-│  ├─ stylehacks@5.1.1
-│  │  ├─ URL: https://github.com/cssnano/cssnano.git
-│  │  ├─ VendorName: Ben Briggs
-│  │  └─ VendorUrl: https://github.com/cssnano/cssnano
-│  ├─ stylis@4.1.3
-│  │  ├─ URL: https://github.com/thysultan/stylis.js
-│  │  ├─ VendorName: Sultan Tarimo
-│  │  └─ VendorUrl: https://github.com/thysultan/stylis.js
-│  ├─ supports-color@5.5.0
-│  │  ├─ URL: https://github.com/chalk/supports-color.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ supports-color@7.2.0
-│  │  ├─ URL: https://github.com/chalk/supports-color.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ supports-color@8.1.1
-│  │  ├─ URL: https://github.com/chalk/supports-color.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ supports-hyperlinks@2.3.0
-│  │  ├─ URL: https://github.com/jamestalmage/supports-hyperlinks.git
-│  │  ├─ VendorName: James Talmage
-│  │  └─ VendorUrl: github.com/jamestalmage
-│  ├─ supports-preserve-symlinks-flag@1.0.0
-│  │  ├─ URL: git+https://github.com/inspect-js/node-supports-preserve-symlinks-flag.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/node-supports-preserve-symlinks-flag#readme
-│  ├─ svg-parser@2.0.4
-│  │  ├─ URL: git+https://github.com/Rich-Harris/svg-parser.git
-│  │  ├─ VendorName: Rich Harris
-│  │  └─ VendorUrl: https://github.com/Rich-Harris/svg-parser#README
-│  ├─ svgo@1.3.2
-│  │  ├─ URL: git://github.com/svg/svgo.git
-│  │  ├─ VendorName: Kir Belevich
-│  │  └─ VendorUrl: https://github.com/svg/svgo
-│  ├─ svgo@2.8.0
-│  │  ├─ URL: git://github.com/svg/svgo.git
-│  │  ├─ VendorName: Kir Belevich
-│  │  └─ VendorUrl: https://github.com/svg/svgo
-│  ├─ symbol-tree@3.2.4
-│  │  ├─ URL: https://github.com/jsdom/js-symbol-tree.git
-│  │  ├─ VendorName: Joris van der Wel
-│  │  └─ VendorUrl: https://github.com/jsdom/js-symbol-tree#symbol-tree
-│  ├─ tailwindcss@3.2.4
-│  │  ├─ URL: https://github.com/tailwindlabs/tailwindcss.git
-│  │  └─ VendorUrl: https://tailwindcss.com/
-│  ├─ tapable@1.1.3
-│  │  ├─ URL: http://github.com/webpack/tapable.git
-│  │  ├─ VendorName: Tobias Koppers @sokra
-│  │  └─ VendorUrl: https://github.com/webpack/tapable
-│  ├─ tapable@2.2.1
-│  │  ├─ URL: http://github.com/webpack/tapable.git
-│  │  ├─ VendorName: Tobias Koppers @sokra
-│  │  └─ VendorUrl: https://github.com/webpack/tapable
-│  ├─ temp-dir@2.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/temp-dir.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ tempy@0.6.0
-│  │  ├─ URL: https://github.com/sindresorhus/tempy.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ terminal-link@2.1.1
-│  │  ├─ URL: https://github.com/sindresorhus/terminal-link.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ terser-webpack-plugin@5.3.6
-│  │  ├─ URL: https://github.com/webpack-contrib/terser-webpack-plugin.git
-│  │  ├─ VendorName: webpack Contrib Team
-│  │  └─ VendorUrl: https://github.com/webpack-contrib/terser-webpack-plugin
-│  ├─ text-table@0.2.0
-│  │  ├─ URL: git://github.com/substack/text-table.git
-│  │  ├─ VendorName: James Halliday
-│  │  └─ VendorUrl: https://github.com/substack/text-table
-│  ├─ throat@6.0.2
-│  │  ├─ URL: https://github.com/ForbesLindesay/throat.git
-│  │  └─ VendorName: ForbesLindesay
-│  ├─ thunky@1.1.0
-│  │  ├─ URL: git://github.com/mafintosh/thunky.git
-│  │  ├─ VendorName: Mathias Buus Madsen
-│  │  └─ VendorUrl: https://github.com/mafintosh/thunky#readme
-│  ├─ tiny-invariant@1.3.1
-│  │  ├─ URL: https://github.com/alexreardon/tiny-invariant.git
-│  │  └─ VendorName: Alex Reardon
-│  ├─ tiny-warning@1.0.3
-│  │  ├─ URL: https://github.com/alexreardon/tiny-warning.git
-│  │  └─ VendorName: Alex Reardon
-│  ├─ to-camel-case@1.0.0
-│  │  └─ URL: git://github.com/ianstormtaylor/to-camel-case.git
-│  ├─ to-fast-properties@2.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/to-fast-properties.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ to-no-case@1.0.2
-│  │  └─ URL: git://github.com/ianstormtaylor/to-no-case.git
-│  ├─ to-regex-range@5.0.1
-│  │  ├─ URL: https://github.com/micromatch/to-regex-range.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/micromatch/to-regex-range
-│  ├─ to-space-case@1.0.0
-│  │  └─ URL: git://github.com/ianstormtaylor/to-space-case.git
-│  ├─ toidentifier@1.0.1
-│  │  ├─ URL: https://github.com/component/toidentifier.git
-│  │  └─ VendorName: Douglas Christopher Wilson
-│  ├─ tr46@1.0.1
-│  │  ├─ URL: https://github.com/Sebmaster/tr46.js.git
-│  │  └─ VendorName: Sebastian Mayr
-│  ├─ tr46@2.1.0
-│  │  ├─ URL: https://github.com/jsdom/tr46
-│  │  └─ VendorName: Sebastian Mayr
-│  ├─ tryer@1.0.1
-│  │  ├─ URL: git+https://gitlab.com/philbooth/tryer.git
-│  │  ├─ VendorName: Phil Booth
-│  │  └─ VendorUrl: https://gitlab.com/philbooth/tryer
-│  ├─ tsconfig-paths@3.14.1
-│  │  ├─ URL: https://github.com/dividab/tsconfig-paths
-│  │  └─ VendorName: Jonas Kello
-│  ├─ tsutils@3.21.0
-│  │  ├─ URL: https://github.com/ajafff/tsutils
-│  │  └─ VendorName: Klaus Meinhardt
-│  ├─ type-check@0.3.2
-│  │  ├─ URL: git://github.com/gkz/type-check.git
-│  │  ├─ VendorName: George Zahariev
-│  │  └─ VendorUrl: https://github.com/gkz/type-check
-│  ├─ type-check@0.4.0
-│  │  ├─ URL: git://github.com/gkz/type-check.git
-│  │  ├─ VendorName: George Zahariev
-│  │  └─ VendorUrl: https://github.com/gkz/type-check
-│  ├─ type-detect@4.0.8
-│  │  ├─ URL: git+ssh://git@github.com/chaijs/type-detect.git
-│  │  ├─ VendorName: Jake Luer
-│  │  └─ VendorUrl: http://alogicalparadox.com
-│  ├─ type-is@1.6.18
-│  │  └─ URL: https://github.com/jshttp/type-is.git
-│  ├─ typed-array-length@1.0.4
-│  │  ├─ URL: git+https://github.com/inspect-js/typed-array-length.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/typed-array-length#readme
-│  ├─ typedarray-to-buffer@3.1.5
-│  │  ├─ URL: git://github.com/feross/typedarray-to-buffer.git
-│  │  ├─ VendorName: Feross Aboukhadijeh
-│  │  └─ VendorUrl: http://feross.org/
-│  ├─ unbox-primitive@1.0.2
-│  │  ├─ URL: git+https://github.com/ljharb/unbox-primitive.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/ljharb/unbox-primitive#readme
-│  ├─ uncontrollable@7.2.1
-│  │  ├─ URL: git+https://github.com/jquense/uncontrollable.git
-│  │  ├─ VendorName: Jason Quense
-│  │  └─ VendorUrl: https://github.com/jquense/uncontrollable#readme
-│  ├─ unicode-canonical-property-names-ecmascript@2.0.0
-│  │  ├─ URL: https://github.com/mathiasbynens/unicode-canonical-property-names-ecmascript.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://github.com/mathiasbynens/unicode-canonical-property-names-ecmascript
-│  ├─ unicode-match-property-ecmascript@2.0.0
-│  │  ├─ URL: https://github.com/mathiasbynens/unicode-match-property-ecmascript.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://github.com/mathiasbynens/unicode-match-property-ecmascript
-│  ├─ unicode-match-property-value-ecmascript@2.1.0
-│  │  ├─ URL: https://github.com/mathiasbynens/unicode-match-property-value-ecmascript.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://github.com/mathiasbynens/unicode-match-property-value-ecmascript
-│  ├─ unicode-property-aliases-ecmascript@2.1.0
-│  │  ├─ URL: https://github.com/mathiasbynens/unicode-property-aliases-ecmascript.git
-│  │  ├─ VendorName: Mathias Bynens
-│  │  └─ VendorUrl: https://github.com/mathiasbynens/unicode-property-aliases-ecmascript
-│  ├─ unique-string@2.0.0
-│  │  ├─ URL: https://github.com/sindresorhus/unique-string.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: sindresorhus.com
-│  ├─ universalify@0.2.0
-│  │  ├─ URL: git+https://github.com/RyanZim/universalify.git
-│  │  ├─ VendorName: Ryan Zimmerman
-│  │  └─ VendorUrl: https://github.com/RyanZim/universalify#readme
-│  ├─ universalify@2.0.0
-│  │  ├─ URL: git+https://github.com/RyanZim/universalify.git
-│  │  ├─ VendorName: Ryan Zimmerman
-│  │  └─ VendorUrl: https://github.com/RyanZim/universalify#readme
-│  ├─ unpipe@1.0.0
-│  │  ├─ URL: https://github.com/stream-utils/unpipe.git
-│  │  └─ VendorName: Douglas Christopher Wilson
-│  ├─ unquote@1.1.1
-│  │  ├─ URL: https://github.com/lakenen/node-unquote.git
-│  │  ├─ VendorName: Cameron Lakenen
-│  │  └─ VendorUrl: https://github.com/lakenen/node-unquote
-│  ├─ upath@1.2.0
-│  │  ├─ URL: git://github.com/anodynos/upath
-│  │  ├─ VendorName: Angelos Pikoulas
-│  │  └─ VendorUrl: http://github.com/anodynos/upath/
-│  ├─ update-browserslist-db@1.0.10
-│  │  ├─ URL: https://github.com/browserslist/update-db.git
-│  │  └─ VendorName: Andrey Sitnik
-│  ├─ url-parse@1.5.10
-│  │  ├─ URL: https://github.com/unshiftio/url-parse.git
-│  │  └─ VendorName: Arnout Kazemier
-│  ├─ util-deprecate@1.0.2
-│  │  ├─ URL: git://github.com/TooTallNate/util-deprecate.git
-│  │  ├─ VendorName: Nathan Rajlich
-│  │  └─ VendorUrl: https://github.com/TooTallNate/util-deprecate
-│  ├─ util.promisify@1.0.1
-│  │  ├─ URL: git+https://github.com/ljharb/util.promisify.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/ljharb/util.promisify#readme
-│  ├─ utila@0.4.0
-│  │  ├─ URL: https://github.com/AriaMinaei/utila.git
-│  │  └─ VendorName: Aria Minaei
-│  ├─ utils-merge@1.0.1
-│  │  ├─ URL: git://github.com/jaredhanson/utils-merge.git
-│  │  ├─ VendorName: Jared Hanson
-│  │  └─ VendorUrl: http://www.jaredhanson.net/
-│  ├─ uuid@7.0.3
-│  │  └─ URL: https://github.com/uuidjs/uuid.git
-│  ├─ uuid@8.3.2
-│  │  └─ URL: https://github.com/uuidjs/uuid.git
-│  ├─ v8-compile-cache@2.3.0
-│  │  ├─ URL: https://github.com/zertosh/v8-compile-cache.git
-│  │  └─ VendorName: Andres Suarez
-│  ├─ value-equal@1.0.1
-│  │  ├─ URL: https://github.com/mjackson/value-equal.git
-│  │  └─ VendorName: Michael Jackson
-│  ├─ vary@1.1.2
-│  │  ├─ URL: https://github.com/jshttp/vary.git
-│  │  └─ VendorName: Douglas Christopher Wilson
-│  ├─ void-elements@3.1.0
-│  │  ├─ URL: https://github.com/pugjs/void-elements.git
-│  │  ├─ VendorName: hemanth.hm
-│  │  └─ VendorUrl: https://github.com/jadejs/void-elements
-│  ├─ w3c-hr-time@1.0.2
-│  │  ├─ URL: https://github.com/jsdom/w3c-hr-time
-│  │  └─ VendorName: Timothy Gu
-│  ├─ w3c-xmlserializer@2.0.0
-│  │  └─ URL: https://github.com/jsdom/w3c-xmlserializer.git
-│  ├─ warning@4.0.3
-│  │  ├─ URL: https://github.com/BerkeleyTrue/warning.git
-│  │  ├─ VendorName: Berkeley Martinez
-│  │  └─ VendorUrl: https://github.com/BerkeleyTrue/warning
-│  ├─ watchpack@2.4.0
-│  │  ├─ URL: https://github.com/webpack/watchpack.git
-│  │  ├─ VendorName: Tobias Koppers @sokra
-│  │  └─ VendorUrl: https://github.com/webpack/watchpack
-│  ├─ wbuf@1.7.3
-│  │  ├─ URL: git@github.com:indutny/wbuf
-│  │  ├─ VendorName: Fedor Indutny
-│  │  └─ VendorUrl: https://github.com/indutny/wbuf
-│  ├─ webpack-dev-middleware@5.3.3
-│  │  ├─ URL: https://github.com/webpack/webpack-dev-middleware.git
-│  │  ├─ VendorName: Tobias Koppers @sokra
-│  │  └─ VendorUrl: https://github.com/webpack/webpack-dev-middleware
-│  ├─ webpack-dev-server@4.11.1
-│  │  ├─ URL: https://github.com/webpack/webpack-dev-server
-│  │  ├─ VendorName: Tobias Koppers @sokra
-│  │  └─ VendorUrl: https://github.com/webpack/webpack-dev-server#readme
-│  ├─ webpack-manifest-plugin@4.1.1
-│  │  ├─ URL: https://github.com/shellscape/webpack-manifest-plugin.git
-│  │  ├─ VendorName: Dane Thurber
-│  │  └─ VendorUrl: https://github.com/shellscape/webpack-manifest-plugin
-│  ├─ webpack-sources@1.4.3
-│  │  ├─ URL: git+https://github.com/webpack/webpack-sources.git
-│  │  ├─ VendorName: Tobias Koppers @sokra
-│  │  └─ VendorUrl: https://github.com/webpack/webpack-sources#readme
-│  ├─ webpack-sources@2.3.1
-│  │  ├─ URL: git+https://github.com/webpack/webpack-sources.git
-│  │  ├─ VendorName: Tobias Koppers @sokra
-│  │  └─ VendorUrl: https://github.com/webpack/webpack-sources#readme
-│  ├─ webpack-sources@3.2.3
-│  │  ├─ URL: git+https://github.com/webpack/webpack-sources.git
-│  │  ├─ VendorName: Tobias Koppers @sokra
-│  │  └─ VendorUrl: https://github.com/webpack/webpack-sources#readme
-│  ├─ webpack@5.76.2
-│  │  ├─ URL: https://github.com/webpack/webpack.git
-│  │  ├─ VendorName: Tobias Koppers @sokra
-│  │  └─ VendorUrl: https://github.com/webpack/webpack
-│  ├─ whatwg-encoding@1.0.5
-│  │  ├─ URL: https://github.com/jsdom/whatwg-encoding.git
-│  │  ├─ VendorName: Domenic Denicola
-│  │  └─ VendorUrl: https://domenic.me/
-│  ├─ whatwg-fetch@3.6.2
-│  │  └─ URL: https://github.com/github/fetch.git
-│  ├─ whatwg-mimetype@2.3.0
-│  │  ├─ URL: https://github.com/jsdom/whatwg-mimetype.git
-│  │  ├─ VendorName: Domenic Denicola
-│  │  └─ VendorUrl: https://domenic.me/
-│  ├─ whatwg-url@7.1.0
-│  │  ├─ URL: https://github.com/jsdom/whatwg-url.git
-│  │  └─ VendorName: Sebastian Mayr
-│  ├─ whatwg-url@8.7.0
-│  │  ├─ URL: https://github.com/jsdom/whatwg-url.git
-│  │  └─ VendorName: Sebastian Mayr
-│  ├─ which-boxed-primitive@1.0.2
-│  │  ├─ URL: git+https://github.com/inspect-js/which-boxed-primitive.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/which-boxed-primitive#readme
-│  ├─ which-collection@1.0.1
-│  │  ├─ URL: git+https://github.com/inspect-js/which-collection.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: https://github.com/inspect-js/which-collection#readme
-│  ├─ which-typed-array@1.1.9
-│  │  ├─ URL: git://github.com/inspect-js/which-typed-array.git
-│  │  ├─ VendorName: Jordan Harband
-│  │  └─ VendorUrl: http://ljharb.codes
-│  ├─ word-wrap@1.2.3
-│  │  ├─ URL: https://github.com/jonschlinkert/word-wrap.git
-│  │  ├─ VendorName: Jon Schlinkert
-│  │  └─ VendorUrl: https://github.com/jonschlinkert/word-wrap
-│  ├─ workbox-background-sync@6.5.4
-│  │  ├─ URL: https://github.com/googlechrome/workbox.git
-│  │  ├─ VendorName: Google's Web DevRel Team
-│  │  └─ VendorUrl: https://github.com/GoogleChrome/workbox
-│  ├─ workbox-broadcast-update@6.5.4
-│  │  ├─ URL: https://github.com/googlechrome/workbox.git
-│  │  ├─ VendorName: Google's Web DevRel Team
-│  │  └─ VendorUrl: https://github.com/GoogleChrome/workbox
-│  ├─ workbox-build@6.5.4
-│  │  ├─ URL: https://github.com/googlechrome/workbox.git
-│  │  ├─ VendorName: Google's Web DevRel Team
-│  │  └─ VendorUrl: https://github.com/GoogleChrome/workbox
-│  ├─ workbox-cacheable-response@6.5.4
-│  │  ├─ URL: https://github.com/googlechrome/workbox.git
-│  │  ├─ VendorName: Google's Web DevRel Team
-│  │  └─ VendorUrl: https://github.com/GoogleChrome/workbox
-│  ├─ workbox-core@6.5.4
-│  │  ├─ URL: https://github.com/googlechrome/workbox.git
-│  │  ├─ VendorName: Google's Web DevRel Team
-│  │  └─ VendorUrl: https://github.com/GoogleChrome/workbox
-│  ├─ workbox-expiration@6.5.4
-│  │  ├─ URL: https://github.com/googlechrome/workbox.git
-│  │  ├─ VendorName: Google's Web DevRel Team
-│  │  └─ VendorUrl: https://github.com/GoogleChrome/workbox
-│  ├─ workbox-google-analytics@6.5.4
-│  │  ├─ URL: https://github.com/googlechrome/workbox.git
-│  │  ├─ VendorName: Google's Web DevRel Team
-│  │  └─ VendorUrl: https://github.com/GoogleChrome/workbox
-│  ├─ workbox-navigation-preload@6.5.4
-│  │  ├─ URL: https://github.com/googlechrome/workbox.git
-│  │  ├─ VendorName: Google's Web DevRel Team
-│  │  └─ VendorUrl: https://github.com/GoogleChrome/workbox
-│  ├─ workbox-precaching@6.5.4
-│  │  ├─ URL: https://github.com/googlechrome/workbox.git
-│  │  ├─ VendorName: Google's Web DevRel Team
-│  │  └─ VendorUrl: https://github.com/GoogleChrome/workbox
-│  ├─ workbox-range-requests@6.5.4
-│  │  ├─ URL: https://github.com/googlechrome/workbox.git
-│  │  ├─ VendorName: Google's Web DevRel Team
-│  │  └─ VendorUrl: https://github.com/GoogleChrome/workbox
-│  ├─ workbox-recipes@6.5.4
-│  │  ├─ URL: https://github.com/googlechrome/workbox.git
-│  │  ├─ VendorName: Google's Web DevRel Team
-│  │  └─ VendorUrl: https://github.com/GoogleChrome/workbox
-│  ├─ workbox-routing@6.5.4
-│  │  ├─ URL: https://github.com/googlechrome/workbox.git
-│  │  ├─ VendorName: Google's Web DevRel Team
-│  │  └─ VendorUrl: https://github.com/GoogleChrome/workbox
-│  ├─ workbox-strategies@6.5.4
-│  │  ├─ URL: https://github.com/googlechrome/workbox.git
-│  │  ├─ VendorName: Google's Web DevRel Team
-│  │  └─ VendorUrl: https://github.com/GoogleChrome/workbox
-│  ├─ workbox-streams@6.5.4
-│  │  ├─ URL: https://github.com/googlechrome/workbox.git
-│  │  ├─ VendorName: Google's Web DevRel Team
-│  │  └─ VendorUrl: https://github.com/GoogleChrome/workbox
-│  ├─ workbox-sw@6.5.4
-│  │  ├─ URL: https://github.com/googlechrome/workbox.git
-│  │  ├─ VendorName: Google's Web DevRel Team
-│  │  └─ VendorUrl: https://github.com/GoogleChrome/workbox
-│  ├─ workbox-webpack-plugin@6.5.4
-│  │  ├─ URL: https://github.com/googlechrome/workbox.git
-│  │  ├─ VendorName: Google's Web DevRel Team
-│  │  └─ VendorUrl: https://github.com/GoogleChrome/workbox
-│  ├─ workbox-window@6.5.4
-│  │  ├─ URL: https://github.com/googlechrome/workbox.git
-│  │  ├─ VendorName: Google's Web DevRel Team
-│  │  └─ VendorUrl: https://github.com/GoogleChrome/workbox
-│  ├─ wrap-ansi@7.0.0
-│  │  ├─ URL: https://github.com/chalk/wrap-ansi.git
-│  │  ├─ VendorName: Sindre Sorhus
-│  │  └─ VendorUrl: https://sindresorhus.com
-│  ├─ ws@7.5.9
-│  │  ├─ URL: https://github.com/websockets/ws.git
-│  │  ├─ VendorName: Einar Otto Stangvik
-│  │  └─ VendorUrl: https://github.com/websockets/ws
-│  ├─ ws@8.12.0
-│  │  ├─ URL: https://github.com/websockets/ws.git
-│  │  ├─ VendorName: Einar Otto Stangvik
-│  │  └─ VendorUrl: https://github.com/websockets/ws
-│  ├─ xmlchars@2.2.0
-│  │  ├─ URL: https://github.com/lddubeau/xmlchars.git
-│  │  └─ VendorName: Louis-Dominique Dubeau
-│  ├─ xtend@4.0.2
-│  │  ├─ URL: git://github.com/Raynos/xtend.git
-│  │  ├─ VendorName: Raynos
-│  │  └─ VendorUrl: https://github.com/Raynos/xtend
-│  ├─ yargs@16.2.0
-│  │  ├─ URL: https://github.com/yargs/yargs.git
-│  │  └─ VendorUrl: https://yargs.js.org/
-│  └─ yocto-queue@0.1.0
-│     ├─ URL: https://github.com/sindresorhus/yocto-queue.git
-│     ├─ VendorName: Sindre Sorhus
-│     └─ VendorUrl: https://sindresorhus.com
-├─ MIT*
-│  └─ keycharm@0.2.0
-│     ├─ URL: https://github.com/AlexDM0/keycharm
-│     └─ VendorName: Alex de Mulder
-├─ MPL-2.0
-│  └─ axe-core@4.6.3
-│     ├─ URL: https://github.com/dequelabs/axe-core.git
-│     └─ VendorUrl: https://www.deque.com/axe/
-├─ Python-2.0
-│  └─ argparse@2.0.1
-│     └─ URL: https://github.com/nodeca/argparse.git
-├─ UNKNOWN
-│  └─ emitter-component@1.1.1
-│     └─ URL: https://github.com/component/emitter.git
-├─ Unlicense
-│  ├─ fs-monkey@1.0.3
-│  │  └─ URL: https://github.com/streamich/fs-monkey.git
-│  └─ memfs@3.4.13
-│     └─ URL: https://github.com/streamich/memfs.git
-└─ WTFPL
-   └─ lz-string@1.4.4
-      ├─ URL: https://github.com/pieroxy/lz-string.git
-      ├─ VendorName: pieroxy
-      └─ VendorUrl: http://pieroxy.net/blog/pages/lz-string/index.html
-Done in 1.76s.
+npm/npmjs/-/abab/2.0.6, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/-/accepts/1.3.8, MIT, approved, clearlydefined
+npm/npmjs/-/acorn-globals/6.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/acorn-import-assertions/1.8.0, MIT, approved, clearlydefined
+npm/npmjs/-/acorn-jsx/5.3.2, MIT, approved, clearlydefined
+npm/npmjs/-/acorn-node/1.8.2, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/acorn-walk/7.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/acorn/7.4.1, MIT, approved, clearlydefined
+npm/npmjs/-/acorn/8.8.2, MIT, approved, #6951
+npm/npmjs/-/address/1.2.2, MIT, approved, clearlydefined
+npm/npmjs/-/adjust-sourcemap-loader/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/agent-base/6.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/ajv-formats/2.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/ajv-keywords/3.5.2, MIT, approved, clearlydefined
+npm/npmjs/-/ajv-keywords/5.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/ajv/6.12.6, MIT, approved, #979
+npm/npmjs/-/ajv/8.12.0, MIT AND OFL-1.1 AND (EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0), approved, #6025
+npm/npmjs/-/ansi-colors/4.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/ansi-escapes/4.3.2, MIT, approved, clearlydefined
+npm/npmjs/-/ansi-html-community/0.0.8, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/ansi-regex/5.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/ansi-regex/6.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/ansi-styles/3.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/ansi-styles/4.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/ansi-styles/5.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/anymatch/3.1.3, ISC, approved, #5050
+npm/npmjs/-/arg/5.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/argparse/1.0.10, MIT, approved, #2174
+npm/npmjs/-/argparse/2.0.1, Python-2.0, approved, CQ22954
+npm/npmjs/-/aria-query/5.1.3, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/array-flatten/1.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/array-flatten/2.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/array-includes/3.1.6, MIT, approved, #4577
+npm/npmjs/-/array-union/2.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/array.prototype.flat/1.3.1, MIT, approved, #4574
+npm/npmjs/-/array.prototype.flatmap/1.3.1, MIT, approved, #4651
+npm/npmjs/-/array.prototype.reduce/1.0.5, MIT, approved, clearlydefined
+npm/npmjs/-/array.prototype.tosorted/1.1.1, MIT, approved, #5051
+npm/npmjs/-/asap/2.0.6, MIT, approved, clearlydefined
+npm/npmjs/-/ast-types-flow/0.0.7, ISC, approved, clearlydefined
+npm/npmjs/-/astral-regex/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/async/3.2.4, Apache-2.0 AND MIT, approved, #1553
+npm/npmjs/-/asynckit/0.4.0, MIT, approved, clearlydefined
+npm/npmjs/-/at-least-node/1.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/attr-accept/2.2.2, MIT, approved, clearlydefined
+npm/npmjs/-/autoprefixer/10.4.13, MIT, approved, #7494
+npm/npmjs/-/available-typed-arrays/1.0.5, MIT, approved, clearlydefined
+npm/npmjs/-/axe-core/4.6.3, MPL-2.0, approved, clearlydefined
+npm/npmjs/-/axios/0.27.2, MIT, approved, clearlydefined
+npm/npmjs/-/axobject-query/3.1.1, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/babel-jest/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/babel-loader/8.3.0, MIT, approved, #4618
+npm/npmjs/-/babel-plugin-istanbul/6.1.1, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/-/babel-plugin-jest-hoist/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/babel-plugin-macros/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/babel-plugin-named-asset-import/0.3.8, MIT, approved, clearlydefined
+npm/npmjs/-/babel-plugin-polyfill-corejs2/0.3.3, MIT, approved, clearlydefined
+npm/npmjs/-/babel-plugin-polyfill-corejs3/0.6.0, MIT, approved, clearlydefined
+npm/npmjs/-/babel-plugin-polyfill-regenerator/0.4.1, MIT, approved, clearlydefined
+npm/npmjs/-/babel-plugin-styled-components/2.0.7, MIT, approved, #2948
+npm/npmjs/-/babel-plugin-syntax-jsx/6.18.0, MIT, approved, clearlydefined
+npm/npmjs/-/babel-plugin-transform-react-remove-prop-types/0.4.24, MIT, approved, clearlydefined
+npm/npmjs/-/babel-preset-current-node-syntax/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/babel-preset-jest/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/babel-preset-react-app/10.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/balanced-match/1.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/base64-js/1.3.1, MIT, approved, clearlydefined
+npm/npmjs/-/batch/0.6.1, MIT, approved, clearlydefined
+npm/npmjs/-/bfj/7.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/big.js/5.2.2, MIT, approved, clearlydefined
+npm/npmjs/-/binary-extensions/2.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/bluebird/3.7.2, MIT, approved, clearlydefined
+npm/npmjs/-/body-parser/1.20.1, MIT, approved, clearlydefined
+npm/npmjs/-/bonjour-service/1.1.0, MIT, approved, #7474
+npm/npmjs/-/boolbase/1.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/bootstrap/5.2.3, CC-BY-3.0 AND MIT, approved, #3259
+npm/npmjs/-/brace-expansion/1.1.11, MIT, approved, clearlydefined
+npm/npmjs/-/brace-expansion/2.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/braces/3.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/browser-process-hrtime/1.0.0, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/browserslist/4.21.5, MIT, approved, #7034
+npm/npmjs/-/bser/2.1.1, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/buffer-from/1.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/builtin-modules/3.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/bytes/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/bytes/3.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/call-bind/1.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/callsites/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/camel-case/4.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/camelcase-css/2.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/camelcase/5.3.1, MIT, approved, clearlydefined
+npm/npmjs/-/camelcase/6.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/camelize/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/caniuse-api/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/caniuse-lite/1.0.30001450, CC-BY-4.0, approved, #1196
+npm/npmjs/-/case-sensitive-paths-webpack-plugin/2.4.0, MIT, approved, clearlydefined
+npm/npmjs/-/chalk/2.4.2, MIT, approved, clearlydefined
+npm/npmjs/-/chalk/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/chalk/4.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/char-regex/1.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/char-regex/2.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/check-types/11.2.2, MIT, approved, clearlydefined
+npm/npmjs/-/chokidar/3.5.3, MIT, approved, #2317
+npm/npmjs/-/chrome-trace-event/1.0.3, MIT, approved, #2414
+npm/npmjs/-/ci-info/3.7.1, MIT, approved, clearlydefined
+npm/npmjs/-/cjs-module-lexer/1.2.2, MIT, approved, #9069
+npm/npmjs/-/classnames/2.3.2, MIT, approved, clearlydefined
+npm/npmjs/-/clean-css/5.3.2, MIT, approved, clearlydefined
+npm/npmjs/-/cliui/7.0.4, ISC AND Artistic-2.0, approved, #2724
+npm/npmjs/-/clsx/1.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/co/4.6.0, MIT, approved, clearlydefined
+npm/npmjs/-/coa/2.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/collect-v8-coverage/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/color-convert/1.9.3, MIT, approved, clearlydefined
+npm/npmjs/-/color-convert/2.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/color-name/1.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/color-name/1.1.4, MIT, approved, clearlydefined
+npm/npmjs/-/colord/2.9.3, MIT, approved, clearlydefined
+npm/npmjs/-/colorette/2.0.19, MIT, approved, clearlydefined
+npm/npmjs/-/combined-stream/1.0.8, MIT, approved, clearlydefined
+npm/npmjs/-/commander/2.20.3, MIT, approved, clearlydefined
+npm/npmjs/-/commander/7.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/commander/8.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/common-path-prefix/3.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/common-tags/1.8.2, MIT, approved, #2950
+npm/npmjs/-/commondir/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/compressible/2.0.18, MIT, approved, clearlydefined
+npm/npmjs/-/compression/1.7.4, MIT, approved, #1975
+npm/npmjs/-/concat-map/0.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/confusing-browser-globals/1.0.11, MIT, approved, clearlydefined
+npm/npmjs/-/connect-history-api-fallback/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/content-disposition/0.5.4, MIT, approved, clearlydefined
+npm/npmjs/-/content-type/1.0.5, MIT, approved, #6950
+npm/npmjs/-/convert-source-map/1.9.0, MIT, approved, clearlydefined
+npm/npmjs/-/cookie-signature/1.0.6, MIT, approved, clearlydefined
+npm/npmjs/-/cookie/0.5.0, MIT, approved, clearlydefined
+npm/npmjs/-/core-js-compat/3.27.2, MIT AND BSD-3-Clause, approved, #6014
+npm/npmjs/-/core-js-pure/3.27.2, MIT, approved, clearlydefined
+npm/npmjs/-/core-js/3.27.2, MIT AND BSD-3-Clause, approved, #6015
+npm/npmjs/-/core-util-is/1.0.3, MIT, approved, #5898
+npm/npmjs/-/cosmiconfig/6.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/cosmiconfig/7.1.0, MIT, approved, #4975
+npm/npmjs/-/cross-spawn/7.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/crypto-random-string/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/css-blank-pseudo/3.0.3, CC0-1.0, approved, clearlydefined
+npm/npmjs/-/css-color-keywords/1.0.0, ISC, approved, #2951
+npm/npmjs/-/css-declaration-sorter/6.3.1, ISC, approved, clearlydefined
+npm/npmjs/-/css-has-pseudo/3.0.4, CC0-1.0, approved, clearlydefined
+npm/npmjs/-/css-loader/6.7.3, MIT, approved, #4985
+npm/npmjs/-/css-minimizer-webpack-plugin/3.4.1, MIT, approved, clearlydefined
+npm/npmjs/-/css-prefers-color-scheme/6.0.3, CC0-1.0, approved, clearlydefined
+npm/npmjs/-/css-select-base-adapter/0.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/css-select/2.1.0, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/css-select/4.3.0, BSD-2-Clause AND MIT AND (MIT AND MIT-0), approved, #3227
+npm/npmjs/-/css-to-react-native/3.1.0, MIT, approved, #7033
+npm/npmjs/-/css-tree/1.0.0-alpha.37, MIT, approved, #1287
+npm/npmjs/-/css-tree/1.1.3, MIT, approved, #1283
+npm/npmjs/-/css-what/3.4.2, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/css-what/6.1.0, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/css.escape/1.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/cssdb/7.4.1, CC0-1.0, approved, #7036
+npm/npmjs/-/cssesc/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/cssnano-preset-default/5.2.13, MIT, approved, clearlydefined
+npm/npmjs/-/cssnano-utils/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/cssnano/5.1.14, MIT, approved, clearlydefined
+npm/npmjs/-/csso/4.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/cssom/0.3.8, MIT, approved, clearlydefined
+npm/npmjs/-/cssom/0.4.4, MIT, approved, clearlydefined
+npm/npmjs/-/cssstyle/2.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/csstype/3.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/damerau-levenshtein/1.0.8, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/data-urls/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/date-fns/2.29.3, MIT, approved, clearlydefined
+npm/npmjs/-/debug/2.6.9, MIT, approved, clearlydefined
+npm/npmjs/-/debug/3.2.7, MIT, approved, clearlydefined
+npm/npmjs/-/debug/4.3.4, MIT, approved, clearlydefined
+npm/npmjs/-/decimal.js/10.4.3, MIT, approved, clearlydefined
+npm/npmjs/-/dedent/0.7.0, MIT, approved, clearlydefined
+npm/npmjs/-/deep-equal/2.2.0, MIT, approved, #8406
+npm/npmjs/-/deep-is/0.1.4, MIT, approved, #2130
+npm/npmjs/-/deepmerge/4.3.0, MIT, approved, #7032
+npm/npmjs/-/default-gateway/6.0.3, BSD-2-Clause AND BSD-3-Clause, approved, #2956
+npm/npmjs/-/define-lazy-prop/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/define-properties/1.1.4, MIT, approved, clearlydefined
+npm/npmjs/-/defined/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/delayed-stream/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/depd/1.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/depd/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/dequal/2.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/destroy/1.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/detect-newline/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/detect-node/2.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/detect-port-alt/1.1.6, MIT, approved, clearlydefined
+npm/npmjs/-/detective/5.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/didyoumean/1.2.2, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/diff-sequences/27.5.1, 0BSD AND Apache-2.0 AND BSD-2-Clause AND MIT, approved, #1953
+npm/npmjs/-/diff-sequences/29.3.1, MIT, approved, clearlydefined
+npm/npmjs/-/dir-glob/3.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/dlv/1.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/dns-equal/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/dns-packet/5.4.0, MIT, approved, clearlydefined
+npm/npmjs/-/doctrine/2.1.0, Apache-2.0 AND BSD-2-Clause, approved, #1987
+npm/npmjs/-/doctrine/3.0.0, Apache-2.0 AND BSD-2-Clause, approved, CQ22628
+npm/npmjs/-/dom-accessibility-api/0.5.16, MIT, approved, clearlydefined
+npm/npmjs/-/dom-converter/0.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/dom-helpers/5.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/dom-serializer/0.2.2, MIT, approved, clearlydefined
+npm/npmjs/-/dom-serializer/1.4.1, MIT, approved, clearlydefined
+npm/npmjs/-/domelementtype/1.3.1, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/domelementtype/2.3.0, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/domexception/2.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/domhandler/4.3.1, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/domutils/1.7.0, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/domutils/2.8.0, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/dot-case/3.0.4, MIT, approved, clearlydefined
+npm/npmjs/-/dotenv-expand/5.1.0, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/dotenv/10.0.0, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/duplexer/0.1.2, MIT, approved, #1002
+npm/npmjs/-/ee-first/1.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/ejs/3.1.8, Apache-2.0, approved, #1373
+npm/npmjs/-/electron-to-chromium/1.4.288, ISC, approved, #1950
+npm/npmjs/-/emitter-component/1.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/emittery/0.10.2, MIT, approved, clearlydefined
+npm/npmjs/-/emittery/0.8.1, MIT, approved, clearlydefined
+npm/npmjs/-/emoji-regex/8.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/emoji-regex/9.2.2, MIT, approved, clearlydefined
+npm/npmjs/-/emojis-list/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/encodeurl/1.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/enhanced-resolve/5.12.0, MIT, approved, clearlydefined
+npm/npmjs/-/enquirer/2.3.6, MIT AND (ISC AND MIT), approved, #2727
+npm/npmjs/-/entities/2.2.0, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/error-ex/1.3.2, MIT, approved, clearlydefined
+npm/npmjs/-/error-stack-parser/2.1.4, MIT, approved, clearlydefined
+npm/npmjs/-/es-abstract/1.21.1, MIT, approved, #6209
+npm/npmjs/-/es-array-method-boxes-properly/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/es-get-iterator/1.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/es-module-lexer/0.9.3, MIT, approved, #1206
+npm/npmjs/-/es-set-tostringtag/2.0.1, MIT, approved, #6218
+npm/npmjs/-/es-shim-unscopables/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/es-to-primitive/1.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/escalade/3.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/escape-html/1.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/escape-string-regexp/1.0.5, MIT, approved, clearlydefined
+npm/npmjs/-/escape-string-regexp/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/escape-string-regexp/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/escodegen/2.0.0, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/eslint-config-react-app/7.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/eslint-import-resolver-node/0.3.7, MIT, approved, clearlydefined
+npm/npmjs/-/eslint-module-utils/2.7.4, MIT, approved, #2500
+npm/npmjs/-/eslint-plugin-flowtype/8.0.3, BSD-3-Clause, approved, #2958
+npm/npmjs/-/eslint-plugin-import/2.27.5, MIT, approved, #6937
+npm/npmjs/-/eslint-plugin-jest/25.7.0, MIT AND (BSD-2-Clause AND MIT), approved, #2961
+npm/npmjs/-/eslint-plugin-jsx-a11y/6.7.1, MIT, approved, clearlydefined
+npm/npmjs/-/eslint-plugin-react-hooks/4.6.0, MIT, approved, clearlydefined
+npm/npmjs/-/eslint-plugin-react/7.32.2, MIT, approved, #7035
+npm/npmjs/-/eslint-plugin-testing-library/5.10.0, MIT, approved, #7038
+npm/npmjs/-/eslint-scope/5.1.1, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/eslint-scope/7.1.1, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/eslint-utils/2.1.0, MIT, approved, #2498
+npm/npmjs/-/eslint-utils/3.0.0, MIT, approved, #2431
+npm/npmjs/-/eslint-visitor-keys/1.3.0, Apache-2.0, approved, #2501
+npm/npmjs/-/eslint-visitor-keys/2.1.0, Apache-2.0, approved, #2433
+npm/npmjs/-/eslint-visitor-keys/3.3.0, Apache-2.0, approved, #2696
+npm/npmjs/-/eslint-webpack-plugin/3.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/eslint/7.32.0, MIT, approved, #2726
+npm/npmjs/-/eslint/8.33.0, , approved, #7039
+npm/npmjs/-/espree/7.3.1, BSD-2-Clause AND MIT, approved, #903
+npm/npmjs/-/espree/9.4.1, BSD-2-Clause AND BSD-3-Clause AND MIT AND BSD-2-Clause, approved, #3231
+npm/npmjs/-/esprima/4.0.1, BSD-2-Clause, approved, #995
+npm/npmjs/-/esquery/1.4.0, BSD-3-Clause, approved, #1100
+npm/npmjs/-/esrecurse/4.3.0, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/estraverse/4.3.0, BSD-2-Clause, approved, #518
+npm/npmjs/-/estraverse/5.3.0, BSD-2-Clause AND MIT, approved, #1557
+npm/npmjs/-/estree-walker/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/esutils/2.0.3, BSD-2-Clause AND BSD-3-Clause, approved, #120
+npm/npmjs/-/etag/1.8.1, MIT, approved, clearlydefined
+npm/npmjs/-/eventemitter3/4.0.7, MIT, approved, clearlydefined
+npm/npmjs/-/events/3.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/execa/5.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/exit/0.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/expect/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/expect/29.4.1, MIT, approved, clearlydefined
+npm/npmjs/-/express/4.18.2, MIT, approved, clearlydefined
+npm/npmjs/-/fast-deep-equal/3.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/fast-glob/3.2.12, MIT, approved, clearlydefined
+npm/npmjs/-/fast-json-stable-stringify/2.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/fast-levenshtein/2.0.6, MIT, approved, #2428
+npm/npmjs/-/fastq/1.15.0, ISC, approved, #6021
+npm/npmjs/-/faye-websocket/0.11.4, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/fb-watchman/2.0.2, MIT AND Apache-2.0, approved, #5379
+npm/npmjs/-/file-entry-cache/6.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/file-loader/6.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/file-selector/0.4.0, MIT, approved, #2960
+npm/npmjs/-/filelist/1.0.4, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/filesize/8.0.7, BSD-3-Clause, approved, #2965
+npm/npmjs/-/fill-range/7.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/finalhandler/1.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/find-cache-dir/3.3.2, MIT, approved, clearlydefined
+npm/npmjs/-/find-root/1.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/find-up/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/find-up/4.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/find-up/5.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/flat-cache/3.0.4, MIT, approved, clearlydefined
+npm/npmjs/-/flatted/3.2.7, ISC AND (ISC AND MIT), approved, #2430
+npm/npmjs/-/follow-redirects/1.15.2, MIT, approved, clearlydefined
+npm/npmjs/-/for-each/0.3.3, MIT, approved, clearlydefined
+npm/npmjs/-/fork-ts-checker-webpack-plugin/6.5.2, MIT, approved, #7487
+npm/npmjs/-/form-data/3.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/form-data/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/forwarded/0.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/fraction.js/4.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/fresh/0.5.2, MIT, approved, clearlydefined
+npm/npmjs/-/fs-extra/10.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/fs-extra/9.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/fs-monkey/1.0.3, Unlicense AND (ISC AND MIT), approved, #2964
+npm/npmjs/-/fs.realpath/1.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/fsevents/2.3.2, MIT, approved, #2967
+npm/npmjs/-/function-bind/1.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/function.prototype.name/1.1.5, MIT, approved, clearlydefined
+npm/npmjs/-/functional-red-black-tree/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/functions-have-names/1.2.3, MIT, approved, clearlydefined
+npm/npmjs/-/fuse.js/3.6.1, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/gensync/1.0.0-beta.2, MIT, approved, clearlydefined
+npm/npmjs/-/get-caller-file/2.0.5, ISC, approved, clearlydefined
+npm/npmjs/-/get-intrinsic/1.2.0, MIT, approved, #8453
+npm/npmjs/-/get-own-enumerable-property-symbols/3.0.2, ISC, approved, clearlydefined
+npm/npmjs/-/get-package-type/0.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/get-stream/6.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/get-symbol-description/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/glob-parent/5.1.2, ISC, approved, clearlydefined
+npm/npmjs/-/glob-parent/6.0.2, ISC, approved, clearlydefined
+npm/npmjs/-/glob-to-regexp/0.4.1, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/glob/7.2.3, ISC, approved, clearlydefined
+npm/npmjs/-/global-modules/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/global-prefix/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/globals/11.12.0, MIT, approved, clearlydefined
+npm/npmjs/-/globals/13.20.0, MIT, approved, #6953
+npm/npmjs/-/globalthis/1.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/globby/11.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/gopd/1.0.1, MIT, approved, #4863
+npm/npmjs/-/graceful-fs/4.2.10, ISC, approved, #7413
+npm/npmjs/-/grapheme-splitter/1.0.4, MIT, approved, #1645
+npm/npmjs/-/gzip-size/6.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/hammerjs/2.0.8, MIT, approved, #382
+npm/npmjs/-/handle-thing/2.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/harmony-reflect/1.6.2, Apache-2.0 AND MPL-1.1 AND Apache-2.0, approved, #2966
+npm/npmjs/-/has-bigints/1.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/has-flag/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/has-flag/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/has-property-descriptors/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/has-proto/1.0.1, MIT, approved, #6175
+npm/npmjs/-/has-symbols/1.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/has-tostringtag/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/has/1.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/he/1.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/history/4.10.1, MIT, approved, clearlydefined
+npm/npmjs/-/hoist-non-react-statics/3.3.2, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/-/hoopy/0.1.4, MIT, approved, clearlydefined
+npm/npmjs/-/hpack.js/2.1.6, MIT, approved, clearlydefined
+npm/npmjs/-/html-encoding-sniffer/2.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/html-entities/2.3.3, MIT, approved, #9043
+npm/npmjs/-/html-escaper/2.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/html-minifier-terser/6.1.0, MIT AND MPL-1.1, approved, #2968
+npm/npmjs/-/html-parse-stringify/3.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/html-webpack-plugin/5.5.0, MIT, approved, #9078
+npm/npmjs/-/htmlparser2/6.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/http-deceiver/1.2.7, MIT, approved, clearlydefined
+npm/npmjs/-/http-errors/1.6.3, MIT, approved, clearlydefined
+npm/npmjs/-/http-errors/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/http-parser-js/0.5.8, MIT, approved, #2970
+npm/npmjs/-/http-proxy-agent/4.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/http-proxy-middleware/2.0.6, MIT, approved, clearlydefined
+npm/npmjs/-/http-proxy/1.18.1, MIT, approved, clearlydefined
+npm/npmjs/-/https-proxy-agent/5.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/human-signals/2.1.0, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/i18next-browser-languagedetector/6.1.8, MIT, approved, clearlydefined
+npm/npmjs/-/i18next/21.10.0, MIT, approved, #4714
+npm/npmjs/-/iconv-lite/0.4.24, MIT, approved, clearlydefined
+npm/npmjs/-/iconv-lite/0.6.3, MIT, approved, clearlydefined
+npm/npmjs/-/icss-utils/5.1.0, ISC, approved, clearlydefined
+npm/npmjs/-/idb/7.1.1, ISC, approved, clearlydefined
+npm/npmjs/-/identity-obj-proxy/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/ignore/4.0.6, MIT, approved, clearlydefined
+npm/npmjs/-/ignore/5.2.4, MIT, approved, #5907
+npm/npmjs/-/immer/9.0.19, MIT, approved, #7037
+npm/npmjs/-/import-fresh/3.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/import-local/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/imurmurhash/0.1.4, MIT, approved, clearlydefined
+npm/npmjs/-/indent-string/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/inflight/1.0.6, ISC, approved, clearlydefined
+npm/npmjs/-/inherits/2.0.3, ISC, approved, clearlydefined
+npm/npmjs/-/inherits/2.0.4, ISC, approved, clearlydefined
+npm/npmjs/-/ini/1.3.8, ISC AND MIT AND BSD-3-Clause, approved, CQ23023
+npm/npmjs/-/internal-slot/1.0.4, MIT, approved, #7118
+npm/npmjs/-/invariant/2.2.4, MIT, approved, #1034
+npm/npmjs/-/ipaddr.js/1.9.1, MIT, approved, clearlydefined
+npm/npmjs/-/ipaddr.js/2.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/is-arguments/1.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/is-array-buffer/3.0.1, MIT, approved, #6248
+npm/npmjs/-/is-arrayish/0.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/is-bigint/1.0.4, MIT, approved, clearlydefined
+npm/npmjs/-/is-binary-path/2.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/is-boolean-object/1.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/is-callable/1.2.7, MIT, approved, clearlydefined
+npm/npmjs/-/is-core-module/2.11.0, MIT, approved, clearlydefined
+npm/npmjs/-/is-date-object/1.0.5, MIT, approved, clearlydefined
+npm/npmjs/-/is-docker/2.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/is-extglob/2.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/is-fullwidth-code-point/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/is-generator-fn/2.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/is-glob/4.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/is-map/2.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/is-module/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/is-negative-zero/2.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/is-number-object/1.0.7, MIT, approved, clearlydefined
+npm/npmjs/-/is-number/7.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/is-obj/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/is-path-inside/3.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/is-plain-obj/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/is-potential-custom-element-name/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/is-regex/1.1.4, MIT, approved, clearlydefined
+npm/npmjs/-/is-regexp/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/is-root/2.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/is-set/2.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/is-shared-array-buffer/1.0.2, MIT, approved, #1207
+npm/npmjs/-/is-stream/2.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/is-string/1.0.7, MIT, approved, clearlydefined
+npm/npmjs/-/is-symbol/1.0.4, MIT, approved, clearlydefined
+npm/npmjs/-/is-typed-array/1.1.10, MIT, approved, #4853
+npm/npmjs/-/is-typedarray/1.0.0, MIT, approved, #2531
+npm/npmjs/-/is-weakmap/2.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/is-weakref/1.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/is-weakset/2.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/is-wsl/2.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/isarray/0.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/isarray/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/isarray/2.0.5, MIT, approved, clearlydefined
+npm/npmjs/-/isexe/2.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/istanbul-lib-coverage/3.2.0, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/-/istanbul-lib-instrument/5.2.1, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/-/istanbul-lib-report/3.0.0, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/-/istanbul-lib-source-maps/4.0.1, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/-/istanbul-reports/3.1.5, BSD-3-Clause AND MIT, approved, #1710
+npm/npmjs/-/jake/10.8.5, Apache-2.0 AND MIT, approved, #1316
+npm/npmjs/-/jest-changed-files/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-circus/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-cli/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-config/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-diff/27.5.1, 0BSD AND Apache-2.0 AND BSD-2-Clause AND MIT, approved, #1951
+npm/npmjs/-/jest-diff/29.4.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-docblock/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-each/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-environment-jsdom/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-environment-node/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-get-type/27.5.1, 0BSD AND Apache-2.0 AND BSD-2-Clause AND MIT, approved, #1947
+npm/npmjs/-/jest-get-type/29.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/jest-haste-map/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-jasmine2/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-leak-detector/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-matcher-utils/27.5.1, 0BSD AND Apache-2.0 AND BSD-2-Clause AND MIT, approved, #1945
+npm/npmjs/-/jest-matcher-utils/29.4.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-message-util/27.5.1, 0BSD AND Apache-2.0 AND BSD-2-Clause AND MIT, approved, #1943
+npm/npmjs/-/jest-message-util/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest-message-util/29.4.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-mock/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-pnp-resolver/1.2.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest-regex-util/27.5.1, 0BSD AND Apache-2.0 AND BSD-2-Clause AND MIT, approved, #1955
+npm/npmjs/-/jest-regex-util/28.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/jest-resolve-dependencies/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-resolve/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-runner/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-runtime/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-serializer/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-snapshot/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-util/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-util/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest-util/29.4.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-validate/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-watch-typeahead/1.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/jest-watcher/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/jest-watcher/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest-worker/26.6.2, MIT, approved, clearlydefined
+npm/npmjs/-/jest-worker/27.5.1, 0BSD AND Apache-2.0 AND BSD-2-Clause AND MIT, approved, #1952
+npm/npmjs/-/jest-worker/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/jest/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/js-sdsl/4.3.0, MIT, approved, #7040
+npm/npmjs/-/js-sha256/0.9.0, MIT, approved, clearlydefined
+npm/npmjs/-/js-tokens/4.0.0, MIT, approved, #2401
+npm/npmjs/-/js-yaml/3.14.1, MIT, approved, clearlydefined
+npm/npmjs/-/js-yaml/4.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/jsdom/16.7.0, LGPL-2.0-or-later AND MIT, approved, #1370
+npm/npmjs/-/jsesc/0.5.0, MIT, approved, clearlydefined
+npm/npmjs/-/jsesc/2.5.2, MIT, approved, clearlydefined
+npm/npmjs/-/json-parse-even-better-errors/2.3.1, MIT, approved, clearlydefined
+npm/npmjs/-/json-schema-traverse/0.4.1, MIT, approved, clearlydefined
+npm/npmjs/-/json-schema-traverse/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/json-schema/0.4.0, AFL-2.1 OR BSD-3-Clause, approved, #2410
+npm/npmjs/-/json-stable-stringify-without-jsonify/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/json5/1.0.2, MIT, approved, CQ22351
+npm/npmjs/-/json5/2.2.3, MIT, approved, #2126
+npm/npmjs/-/jsonfile/6.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/jsonpointer/5.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/jsx-ast-utils/3.3.3, MIT, approved, clearlydefined
+npm/npmjs/-/just-curry-it/3.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/keycharm/0.2.0, Apache-2.0 AND MIT, approved, #3012
+npm/npmjs/-/keycloak-js/15.1.1, Apache-2.0 AND MIT, approved, #3015
+npm/npmjs/-/kind-of/6.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/kleur/3.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/klona/2.0.6, MIT, approved, clearlydefined
+npm/npmjs/-/language-subtag-registry/0.3.22, CC0-1.0, approved, #3233
+npm/npmjs/-/language-tags/1.0.5, MIT, approved, clearlydefined
+npm/npmjs/-/leven/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/levn/0.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/levn/0.4.1, MIT, approved, clearlydefined
+npm/npmjs/-/lilconfig/2.0.6, MIT, approved, clearlydefined
+npm/npmjs/-/lines-and-columns/1.2.4, MIT, approved, clearlydefined
+npm/npmjs/-/loader-runner/4.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/loader-utils/2.0.4, MIT, approved, #4986
+npm/npmjs/-/loader-utils/3.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/locate-path/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/locate-path/5.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/locate-path/6.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/lodash.debounce/4.0.8, MIT, approved, clearlydefined
+npm/npmjs/-/lodash.memoize/4.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/lodash.merge/4.6.2, MIT, approved, clearlydefined
+npm/npmjs/-/lodash.sortby/4.7.0, MIT, approved, clearlydefined
+npm/npmjs/-/lodash.truncate/4.4.2, MIT, approved, clearlydefined
+npm/npmjs/-/lodash.uniq/4.5.0, MIT, approved, clearlydefined
+npm/npmjs/-/lodash/4.17.21, CC0-1.0 AND MIT, approved, #2096
+npm/npmjs/-/loose-envify/1.4.0, MIT, approved, clearlydefined
+npm/npmjs/-/lower-case/2.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/lru-cache/5.1.1, ISC, approved, clearlydefined
+npm/npmjs/-/lru-cache/6.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/lz-string/1.4.4, MIT AND WTFPL, approved, #1378
+npm/npmjs/-/magic-string/0.25.9, MIT, approved, clearlydefined
+npm/npmjs/-/make-dir/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/makeerror/1.0.12, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/-/mdn-data/2.0.14, CC0-1.0, approved, clearlydefined
+npm/npmjs/-/mdn-data/2.0.4, CC0-1.0, approved, clearlydefined
+npm/npmjs/-/media-typer/0.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/memfs/3.4.13, Unlicense, approved, #2974
+npm/npmjs/-/merge-descriptors/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/merge-stream/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/merge2/1.4.1, MIT, approved, clearlydefined
+npm/npmjs/-/methods/1.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/micromatch/4.0.5, MIT, approved, clearlydefined
+npm/npmjs/-/mime-db/1.52.0, MIT, approved, clearlydefined
+npm/npmjs/-/mime-types/2.1.35, MIT, approved, clearlydefined
+npm/npmjs/-/mime/1.6.0, MIT, approved, clearlydefined
+npm/npmjs/-/mimic-fn/2.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/min-indent/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/mini-css-extract-plugin/2.7.2, MIT, approved, #5004
+npm/npmjs/-/minimalistic-assert/1.0.1, ISC, approved, clearlydefined
+npm/npmjs/-/minimatch/3.1.2, ISC, approved, clearlydefined
+npm/npmjs/-/minimatch/5.1.6, ISC, approved, #5952
+npm/npmjs/-/minimist/1.2.7, MIT, approved, #5886
+npm/npmjs/-/mkdirp/0.5.6, MIT, approved, clearlydefined
+npm/npmjs/-/moment/2.29.4, MIT, approved, clearlydefined
+npm/npmjs/-/ms/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/ms/2.1.2, MIT, approved, #5895
+npm/npmjs/-/ms/2.1.3, MIT, approved, #5895
+npm/npmjs/-/multicast-dns/7.2.5, MIT, approved, clearlydefined
+npm/npmjs/-/nanoid/3.3.4, MIT, approved, #7571
+npm/npmjs/-/natural-compare-lite/1.4.0, MIT, approved, clearlydefined
+npm/npmjs/-/natural-compare/1.4.0, MIT, approved, clearlydefined
+npm/npmjs/-/negotiator/0.6.3, MIT, approved, clearlydefined
+npm/npmjs/-/neo-async/2.6.2, MIT, approved, clearlydefined
+npm/npmjs/-/no-case/3.0.4, MIT, approved, clearlydefined
+npm/npmjs/-/node-forge/1.3.1, (BSD-3-Clause OR GPL-2.0-only) AND MIT, approved, #3014
+npm/npmjs/-/node-int64/0.4.0, MIT, approved, clearlydefined
+npm/npmjs/-/node-releases/2.0.10, MIT, approved, #1954
+npm/npmjs/-/normalize-path/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/normalize-range/0.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/normalize-url/6.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/npm-run-path/4.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/nth-check/2.1.1, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/nwsapi/2.2.2, MIT, approved, #7909
+npm/npmjs/-/object-assign/4.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/object-hash/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/object-inspect/1.12.3, MIT, approved, clearlydefined
+npm/npmjs/-/object-is/1.1.5, MIT, approved, clearlydefined
+npm/npmjs/-/object-keys/1.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/object.assign/4.1.4, MIT, approved, #3232
+npm/npmjs/-/object.entries/1.1.6, MIT, approved, #4671
+npm/npmjs/-/object.fromentries/2.0.6, MIT, approved, #4600
+npm/npmjs/-/object.getownpropertydescriptors/2.1.5, MIT, approved, clearlydefined
+npm/npmjs/-/object.hasown/1.1.2, MIT, approved, #4667
+npm/npmjs/-/object.values/1.1.6, MIT, approved, #4665
+npm/npmjs/-/obuf/1.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/on-finished/2.4.1, MIT, approved, clearlydefined
+npm/npmjs/-/on-headers/1.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/once/1.4.0, ISC, approved, clearlydefined
+npm/npmjs/-/onetime/5.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/open/8.4.0, MIT, approved, #7102
+npm/npmjs/-/optionator/0.8.3, MIT, approved, clearlydefined
+npm/npmjs/-/optionator/0.9.1, MIT, approved, clearlydefined
+npm/npmjs/-/p-limit/2.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/p-limit/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/p-locate/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/p-locate/4.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/p-locate/5.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/p-retry/4.6.2, MIT, approved, clearlydefined
+npm/npmjs/-/p-try/2.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/param-case/3.0.4, MIT, approved, clearlydefined
+npm/npmjs/-/parent-module/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/parse-json/5.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/parse5/6.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/parseurl/1.3.3, MIT, approved, clearlydefined
+npm/npmjs/-/pascal-case/3.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/path-exists/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/path-exists/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/path-is-absolute/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/path-key/3.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/path-parse/1.0.7, MIT, approved, clearlydefined
+npm/npmjs/-/path-to-regexp/0.1.7, MIT, approved, clearlydefined
+npm/npmjs/-/path-to-regexp/1.8.0, MIT, approved, clearlydefined
+npm/npmjs/-/path-type/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/performance-now/2.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/picocolors/0.2.1, ISC, approved, clearlydefined
+npm/npmjs/-/picocolors/1.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/picomatch/2.3.1, MIT, approved, clearlydefined
+npm/npmjs/-/pify/2.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/pirates/4.0.5, MIT, approved, #680
+npm/npmjs/-/pkg-dir/4.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/pkg-up/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-attribute-case-insensitive/5.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-browser-comments/4.0.0, CC0-1.0, approved, clearlydefined
+npm/npmjs/-/postcss-calc/8.2.4, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-clamp/4.1.0, MIT, approved, #3013
+npm/npmjs/-/postcss-color-functional-notation/4.2.4, CC0-1.0, approved, clearlydefined
+npm/npmjs/-/postcss-color-hex-alpha/8.0.4, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-color-rebeccapurple/7.1.1, CC0-1.0, approved, clearlydefined
+npm/npmjs/-/postcss-colormin/5.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-convert-values/5.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-custom-media/8.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-custom-properties/12.1.11, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-custom-selectors/6.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-dir-pseudo-class/6.0.5, CC0-1.0, approved, clearlydefined
+npm/npmjs/-/postcss-discard-comments/5.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-discard-duplicates/5.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-discard-empty/5.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-discard-overridden/5.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-double-position-gradients/3.1.2, CC0-1.0, approved, clearlydefined
+npm/npmjs/-/postcss-env-function/4.0.6, CC0-1.0, approved, clearlydefined
+npm/npmjs/-/postcss-flexbugs-fixes/5.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-focus-visible/6.0.4, CC0-1.0, approved, clearlydefined
+npm/npmjs/-/postcss-focus-within/5.0.4, CC0-1.0, approved, clearlydefined
+npm/npmjs/-/postcss-font-variant/5.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-gap-properties/3.0.5, CC0-1.0, approved, clearlydefined
+npm/npmjs/-/postcss-image-set-function/4.0.7, CC0-1.0, approved, clearlydefined
+npm/npmjs/-/postcss-import/14.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-initial/4.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-js/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-lab-function/4.2.1, CC0-1.0 AND (MIT AND W3C-20150513) AND W3C-20150513 AND MIT, approved, #3020
+npm/npmjs/-/postcss-load-config/3.1.4, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-loader/6.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-logical/5.0.4, CC0-1.0, approved, clearlydefined
+npm/npmjs/-/postcss-media-minmax/5.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-merge-longhand/5.1.7, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-merge-rules/5.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-minify-font-values/5.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-minify-gradients/5.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-minify-params/5.1.4, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-minify-selectors/5.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-modules-extract-imports/3.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/postcss-modules-local-by-default/4.0.0, MIT, approved, #8508
+npm/npmjs/-/postcss-modules-scope/3.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/postcss-modules-values/4.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/postcss-nested/6.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-nesting/10.2.0, CC0-1.0, approved, clearlydefined
+npm/npmjs/-/postcss-normalize-charset/5.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-normalize-display-values/5.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-normalize-positions/5.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-normalize-repeat-style/5.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-normalize-string/5.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-normalize-timing-functions/5.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-normalize-unicode/5.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-normalize-url/5.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-normalize-whitespace/5.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-normalize/10.0.1, CC0-1.0, approved, clearlydefined
+npm/npmjs/-/postcss-opacity-percentage/1.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-ordered-values/5.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-overflow-shorthand/3.0.4, CC0-1.0, approved, clearlydefined
+npm/npmjs/-/postcss-page-break/3.0.4, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-place/7.0.5, CC0-1.0, approved, clearlydefined
+npm/npmjs/-/postcss-preset-env/7.8.3, CC0-1.0, approved, clearlydefined
+npm/npmjs/-/postcss-pseudo-class-any-link/7.1.6, CC0-1.0, approved, clearlydefined
+npm/npmjs/-/postcss-reduce-initial/5.1.1, MIT AND (CC0-1.0 AND MIT) AND CC0-1.0, approved, #2972
+npm/npmjs/-/postcss-reduce-transforms/5.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-replace-overflow-wrap/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-selector-not/6.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-selector-parser/6.0.11, MIT, approved, #5056
+npm/npmjs/-/postcss-svgo/5.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-unique-selectors/5.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/postcss-value-parser/4.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/postcss/7.0.39, MIT, approved, clearlydefined
+npm/npmjs/-/postcss/8.4.21, MIT, approved, #3545
+npm/npmjs/-/prelude-ls/1.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/prelude-ls/1.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/prettier/2.6.2, MIT AND (0BSD AND Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND CC-BY-SA-4.0 AND CC0-1.0 AND ISC AND MIT) AND BSD-2-Clause, approved, #2979
+npm/npmjs/-/pretty-bytes/5.6.0, MIT, approved, clearlydefined
+npm/npmjs/-/pretty-error/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/pretty-format/27.5.1, 0BSD AND Apache-2.0 AND BSD-2-Clause AND MIT, approved, #1948
+npm/npmjs/-/pretty-format/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/pretty-format/29.4.1, MIT, approved, clearlydefined
+npm/npmjs/-/process-nextick-args/2.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/progress/2.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/promise/8.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/prompts/2.4.2, MIT, approved, clearlydefined
+npm/npmjs/-/prop-types-extra/1.1.1, , approved, CQ22354
+npm/npmjs/-/prop-types/15.8.1, MIT, approved, clearlydefined
+npm/npmjs/-/propagating-hammerjs/1.5.0, MIT, approved, clearlydefined
+npm/npmjs/-/proxy-addr/2.0.7, MIT, approved, clearlydefined
+npm/npmjs/-/psl/1.9.0, MIT AND CC0-1.0, approved, #3080
+npm/npmjs/-/punycode/2.3.0, MIT, approved, #6373
+npm/npmjs/-/q/1.5.1, Apache-2.0 AND MIT, approved, #1020
+npm/npmjs/-/qs/6.11.0, BSD-3-Clause, approved, #7556
+npm/npmjs/-/querystringify/2.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/queue-microtask/1.2.3, MIT, approved, clearlydefined
+npm/npmjs/-/quick-lru/5.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/raf/3.4.1, MIT, approved, clearlydefined
+npm/npmjs/-/randombytes/2.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/range-parser/1.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/raw-body/2.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/react-app-polyfill/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/react-bootstrap/2.7.0, MIT AND CC-BY-3.0 AND CC-PDDC, approved, #7041
+npm/npmjs/-/react-datepicker/4.10.0, MIT AND BSD-3-Clause, approved, #7042
+npm/npmjs/-/react-dev-utils/12.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/react-dom/18.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/react-drag-drop-files/2.3.8, MIT AND 0BSD, approved, #3019
+npm/npmjs/-/react-dropzone-uploader/2.11.0, MIT, approved, clearlydefined
+npm/npmjs/-/react-dropzone/11.7.1, MIT, approved, #3016
+npm/npmjs/-/react-error-overlay/6.0.11, MIT, approved, clearlydefined
+npm/npmjs/-/react-fast-compare/3.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/react-i18next/11.18.6, MIT, approved, clearlydefined
+npm/npmjs/-/react-icons/4.7.1, MIT, approved, clearlydefined
+npm/npmjs/-/react-is/16.13.1, MIT, approved, clearlydefined
+npm/npmjs/-/react-is/17.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/react-is/18.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/react-lifecycles-compat/3.0.4, MIT, approved, clearlydefined
+npm/npmjs/-/react-onclickoutside/6.12.2, MIT, approved, clearlydefined
+npm/npmjs/-/react-popper/2.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/react-redux/7.2.9, MIT, approved, #2978
+npm/npmjs/-/react-refresh/0.11.0, MIT, approved, clearlydefined
+npm/npmjs/-/react-router-dom/5.3.4, MIT AND BSD-3-Clause, approved, #3023
+npm/npmjs/-/react-router/5.3.4, MIT AND BSD-3-Clause AND CC-BY-4.0, approved, #3024
+npm/npmjs/-/react-scripts/5.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/react-search-input/0.11.3, MIT, approved, clearlydefined
+npm/npmjs/-/react-toastify/8.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/react-tooltip/4.5.1, MIT, approved, #5006
+npm/npmjs/-/react-transition-group/4.4.5, BSD-3-Clause, approved, CQ22955
+npm/npmjs/-/react/18.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/read-cache/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/readable-stream/2.3.7, MIT, approved, #945
+npm/npmjs/-/readable-stream/3.6.0, MIT, approved, CQ22627
+npm/npmjs/-/readdirp/3.6.0, MIT, approved, #2977
+npm/npmjs/-/recursive-readdir/2.2.3, MIT, approved, clearlydefined
+npm/npmjs/-/redent/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/reduce-reducers/0.4.3, MIT, approved, clearlydefined
+npm/npmjs/-/redux-actions/2.6.5, MIT, approved, clearlydefined
+npm/npmjs/-/redux-thunk/2.4.2, MIT, approved, clearlydefined
+npm/npmjs/-/redux/4.2.1, CC0-1.0 AND MIT, approved, #7046
+npm/npmjs/-/regenerate-unicode-properties/10.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/regenerate/1.4.2, MIT, approved, clearlydefined
+npm/npmjs/-/regenerator-runtime/0.13.11, MIT, approved, #4978
+npm/npmjs/-/regenerator-transform/0.15.1, MIT, approved, #5001
+npm/npmjs/-/regex-parser/2.2.11, MIT, approved, clearlydefined
+npm/npmjs/-/regexp.prototype.flags/1.4.3, MIT, approved, clearlydefined
+npm/npmjs/-/regexpp/3.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/regexpu-core/5.2.2, MIT, approved, #4988
+npm/npmjs/-/regjsgen/0.7.1, MIT, approved, clearlydefined
+npm/npmjs/-/regjsparser/0.9.1, BSD-2-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #3329
+npm/npmjs/-/relateurl/0.2.7, MIT, approved, clearlydefined
+npm/npmjs/-/renderkid/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/require-directory/2.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/require-from-string/2.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/requires-port/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/reselect/4.1.7, MIT, approved, clearlydefined
+npm/npmjs/-/resolve-cwd/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/resolve-from/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/resolve-from/5.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/resolve-pathname/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/resolve-url-loader/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/resolve.exports/1.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/resolve/1.22.1, MIT AND ISC, approved, #2409
+npm/npmjs/-/resolve/2.0.0-next.4, MIT AND ISC, approved, #3078
+npm/npmjs/-/retry/0.13.1, MIT, approved, clearlydefined
+npm/npmjs/-/reusify/1.0.4, MIT, approved, clearlydefined
+npm/npmjs/-/rimraf/3.0.2, ISC, approved, clearlydefined
+npm/npmjs/-/rollup-plugin-terser/7.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/rollup/2.79.1, MIT, approved, clearlydefined
+npm/npmjs/-/run-parallel/1.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/safe-buffer/5.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/safe-buffer/5.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/safe-regex-test/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/safer-buffer/2.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/sanitize.css/13.0.0, CC0-1.0, approved, clearlydefined
+npm/npmjs/-/sass-loader/12.6.0, MIT, approved, clearlydefined
+npm/npmjs/-/sax/1.2.4, ISC AND MIT AND ISC, approved, #5889
+npm/npmjs/-/saxes/5.0.1, ISC, approved, clearlydefined
+npm/npmjs/-/scheduler/0.23.0, MIT, approved, clearlydefined
+npm/npmjs/-/schema-utils/2.7.0, MIT, approved, clearlydefined
+npm/npmjs/-/schema-utils/2.7.1, MIT, approved, clearlydefined
+npm/npmjs/-/schema-utils/3.1.1, MIT, approved, #7963
+npm/npmjs/-/schema-utils/4.0.0, MIT, approved, #8213
+npm/npmjs/-/select-hose/2.0.0, MIT, approved, #145
+npm/npmjs/-/selfsigned/2.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/semver/6.3.0, ISC, approved, clearlydefined
+npm/npmjs/-/semver/7.3.8, ISC, approved, clearlydefined
+npm/npmjs/-/send/0.18.0, MIT, approved, clearlydefined
+npm/npmjs/-/serialize-javascript/4.0.0, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/-/serialize-javascript/6.0.1, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/-/serve-index/1.9.1, MIT, approved, clearlydefined
+npm/npmjs/-/serve-static/1.15.0, MIT, approved, clearlydefined
+npm/npmjs/-/setprototypeof/1.1.0, ISC, approved, clearlydefined
+npm/npmjs/-/setprototypeof/1.2.0, ISC, approved, clearlydefined
+npm/npmjs/-/shallowequal/1.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/shebang-command/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/shebang-regex/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/shell-quote/1.8.0, MIT, approved, #7044
+npm/npmjs/-/side-channel/1.0.4, MIT, approved, clearlydefined
+npm/npmjs/-/signal-exit/3.0.7, ISC, approved, #5892
+npm/npmjs/-/sisteransi/1.0.5, MIT, approved, clearlydefined
+npm/npmjs/-/slash/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/slash/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/slice-ansi/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/sockjs/0.3.24, MIT, approved, #2985
+npm/npmjs/-/source-list-map/2.0.1, BSD-3-Clause AND MIT, approved, #978
+npm/npmjs/-/source-map-js/1.0.2, BSD-3-Clause, approved, #2412
+npm/npmjs/-/source-map-loader/3.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/source-map-support/0.5.21, MIT, approved, clearlydefined
+npm/npmjs/-/source-map/0.5.7, BSD-3-Clause, approved, #2400
+npm/npmjs/-/source-map/0.6.1, BSD-3-Clause, approved, #2417
+npm/npmjs/-/source-map/0.7.4, BSD-3-Clause, approved, #2416
+npm/npmjs/-/source-map/0.8.0-beta.0, BSD-3-Clause, approved, #2984
+npm/npmjs/-/sourcemap-codec/1.4.8, MIT, approved, clearlydefined
+npm/npmjs/-/spdy-transport/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/spdy/4.0.2, MIT, approved, #2926
+npm/npmjs/-/sprintf-js/1.0.3, BSD-3-Clause, approved, #949
+npm/npmjs/-/stable/0.1.8, MIT, approved, clearlydefined
+npm/npmjs/-/stack-utils/2.0.6, MIT, approved, clearlydefined
+npm/npmjs/-/stackframe/1.3.4, MIT, approved, clearlydefined
+npm/npmjs/-/statuses/1.5.0, MIT, approved, clearlydefined
+npm/npmjs/-/statuses/2.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/stop-iteration-iterator/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/string-length/4.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/string-length/5.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/string-natural-compare/3.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/string-width/4.2.3, MIT, approved, clearlydefined
+npm/npmjs/-/string.prototype.matchall/4.0.8, MIT, approved, #4571
+npm/npmjs/-/string.prototype.trimend/1.0.6, MIT, approved, #4564
+npm/npmjs/-/string.prototype.trimstart/1.0.6, MIT, approved, #4647
+npm/npmjs/-/string_decoder/1.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/string_decoder/1.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/stringify-object/3.3.0, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/strip-ansi/6.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/strip-ansi/7.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/strip-bom/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/strip-bom/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/strip-comments/2.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/strip-final-newline/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/strip-indent/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/strip-json-comments/3.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/style-loader/3.3.1, MIT, approved, clearlydefined
+npm/npmjs/-/styled-components/5.3.6, MIT, approved, #3021
+npm/npmjs/-/stylehacks/5.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/stylis/4.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/supports-color/5.5.0, MIT, approved, clearlydefined
+npm/npmjs/-/supports-color/7.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/supports-color/8.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/supports-hyperlinks/2.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/supports-preserve-symlinks-flag/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/svg-parser/2.0.4, MIT, approved, clearlydefined
+npm/npmjs/-/svgo/1.3.2, MIT, approved, clearlydefined
+npm/npmjs/-/svgo/2.8.0, MIT AND (0BSD AND BSD-2-Clause AND MIT) AND Apache-2.0, approved, #2989
+npm/npmjs/-/symbol-tree/3.2.4, MIT, approved, clearlydefined
+npm/npmjs/-/table/6.8.1, BSD-3-Clause, approved, #4596
+npm/npmjs/-/tailwindcss/3.2.4, MIT, approved, clearlydefined
+npm/npmjs/-/tapable/1.1.3, MIT, approved, clearlydefined
+npm/npmjs/-/tapable/2.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/temp-dir/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/tempy/0.6.0, MIT, approved, clearlydefined
+npm/npmjs/-/terminal-link/2.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/terser-webpack-plugin/5.3.6, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #7461
+npm/npmjs/-/terser/5.16.3, BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause AND ISC, approved, #7045
+npm/npmjs/-/test-exclude/6.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/text-table/0.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/throat/6.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/thunky/1.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/tiny-invariant/1.3.1, MIT, approved, clearlydefined
+npm/npmjs/-/tiny-warning/1.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/tmpl/1.0.5, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/-/to-camel-case/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/to-fast-properties/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/to-no-case/1.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/to-regex-range/5.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/to-space-case/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/toidentifier/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/tough-cookie/4.1.2, BSD-3-Clause AND MIT, approved, #8743
+npm/npmjs/-/tr46/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/tr46/2.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/tryer/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/tsconfig-paths/3.14.1, MIT, approved, clearlydefined
+npm/npmjs/-/tslib/1.14.1, 0BSD, approved, clearlydefined
+npm/npmjs/-/tslib/2.5.0, 0BSD, approved, #6747
+npm/npmjs/-/tsutils/3.21.0, MIT, approved, clearlydefined
+npm/npmjs/-/type-check/0.3.2, MIT, approved, clearlydefined
+npm/npmjs/-/type-check/0.4.0, MIT, approved, clearlydefined
+npm/npmjs/-/type-detect/4.0.8, MIT, approved, clearlydefined
+npm/npmjs/-/type-fest/0.16.0, MIT OR (CC0-1.0 AND MIT), approved, clearlydefined
+npm/npmjs/-/type-fest/0.20.2, MIT OR (CC0-1.0 AND MIT), approved, clearlydefined
+npm/npmjs/-/type-fest/0.21.3, MIT OR (CC0-1.0 AND MIT), approved, clearlydefined
+npm/npmjs/-/type-is/1.6.18, MIT, approved, clearlydefined
+npm/npmjs/-/typed-array-length/1.0.4, MIT, approved, #6246
+npm/npmjs/-/typedarray-to-buffer/3.1.5, MIT, approved, clearlydefined
+npm/npmjs/-/typescript/4.9.5, Apache-2.0 AND (CC-BY-4.0 AND LicenseRef-scancode-khronos AND LicenseRef-scancode-unicode AND MIT AND W3C-20150513), approved, #4979
+npm/npmjs/-/unbox-primitive/1.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/uncontrollable/7.2.1, MIT AND BSD-3-Clause, approved, #3025
+npm/npmjs/-/unicode-canonical-property-names-ecmascript/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/unicode-match-property-ecmascript/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/unicode-match-property-value-ecmascript/2.1.0, MIT, approved, #4991
+npm/npmjs/-/unicode-property-aliases-ecmascript/2.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/unique-string/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/universalify/0.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/universalify/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/unpipe/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/unquote/1.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/upath/1.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/update-browserslist-db/1.0.10, MIT, approved, #8237
+npm/npmjs/-/uri-js/4.4.1, BSD-2-Clause, approved, #1086
+npm/npmjs/-/url-parse/1.5.10, MIT, approved, clearlydefined
+npm/npmjs/-/util-deprecate/1.0.2, MIT, approved, #5885
+npm/npmjs/-/util.promisify/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/utila/0.4.0, MIT, approved, clearlydefined
+npm/npmjs/-/utils-merge/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/uuid/7.0.3, MIT, approved, #57
+npm/npmjs/-/uuid/8.3.2, MIT AND (BSD-3-Clause AND MIT), approved, #2438
+npm/npmjs/-/v8-compile-cache/2.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/v8-to-istanbul/8.1.1, ISC, approved, clearlydefined
+npm/npmjs/-/value-equal/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/vary/1.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/vis/4.21.0-EOL, MIT OR (Apache-2.0 AND MIT), approved, clearlydefined
+npm/npmjs/-/void-elements/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/w3c-hr-time/1.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/w3c-xmlserializer/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/walker/1.0.8, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/warning/4.0.3, MIT, approved, CQ22359
+npm/npmjs/-/watchpack/2.4.0, MIT, approved, clearlydefined
+npm/npmjs/-/wbuf/1.7.3, MIT, approved, clearlydefined
+npm/npmjs/-/web-vitals/2.1.4, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/webidl-conversions/4.0.2, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/webidl-conversions/5.0.0, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/webidl-conversions/6.1.0, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/webpack-dev-middleware/5.3.3, MIT, approved, clearlydefined
+npm/npmjs/-/webpack-dev-server/4.11.1, MIT, approved, clearlydefined
+npm/npmjs/-/webpack-manifest-plugin/4.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/webpack-sources/1.4.3, MIT, approved, clearlydefined
+npm/npmjs/-/webpack-sources/2.3.1, MIT, approved, clearlydefined
+npm/npmjs/-/webpack-sources/3.2.3, MIT, approved, clearlydefined
+npm/npmjs/-/webpack/5.76.2, MIT, approved, #7409
+npm/npmjs/-/websocket-driver/0.7.4, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/websocket-extensions/0.1.4, Apache-2.0, approved, CQ23021
+npm/npmjs/-/whatwg-encoding/1.0.5, MIT, approved, clearlydefined
+npm/npmjs/-/whatwg-fetch/3.6.2, MIT, approved, clearlydefined
+npm/npmjs/-/whatwg-mimetype/2.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/whatwg-url/7.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/whatwg-url/8.7.0, MIT, approved, clearlydefined
+npm/npmjs/-/which-boxed-primitive/1.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/which-collection/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/which-typed-array/1.1.9, MIT, approved, #4864
+npm/npmjs/-/which/1.3.1, ISC, approved, clearlydefined
+npm/npmjs/-/which/2.0.2, ISC, approved, clearlydefined
+npm/npmjs/-/word-wrap/1.2.3, MIT, approved, clearlydefined
+npm/npmjs/-/workbox-background-sync/6.5.4, MIT, approved, clearlydefined
+npm/npmjs/-/workbox-broadcast-update/6.5.4, MIT, approved, clearlydefined
+npm/npmjs/-/workbox-build/6.5.4, MIT, approved, clearlydefined
+npm/npmjs/-/workbox-cacheable-response/6.5.4, MIT, approved, clearlydefined
+npm/npmjs/-/workbox-core/6.5.4, MIT, approved, clearlydefined
+npm/npmjs/-/workbox-expiration/6.5.4, MIT, approved, clearlydefined
+npm/npmjs/-/workbox-google-analytics/6.5.4, MIT, approved, clearlydefined
+npm/npmjs/-/workbox-navigation-preload/6.5.4, MIT, approved, clearlydefined
+npm/npmjs/-/workbox-precaching/6.5.4, MIT, approved, clearlydefined
+npm/npmjs/-/workbox-range-requests/6.5.4, MIT, approved, clearlydefined
+npm/npmjs/-/workbox-recipes/6.5.4, MIT, approved, clearlydefined
+npm/npmjs/-/workbox-routing/6.5.4, MIT, approved, clearlydefined
+npm/npmjs/-/workbox-strategies/6.5.4, MIT, approved, clearlydefined
+npm/npmjs/-/workbox-streams/6.5.4, MIT, approved, clearlydefined
+npm/npmjs/-/workbox-sw/6.5.4, MIT, approved, clearlydefined
+npm/npmjs/-/workbox-webpack-plugin/6.5.4, MIT, approved, clearlydefined
+npm/npmjs/-/workbox-window/6.5.4, MIT, approved, clearlydefined
+npm/npmjs/-/wrap-ansi/7.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/wrappy/1.0.2, ISC, approved, clearlydefined
+npm/npmjs/-/write-file-atomic/3.0.3, ISC, approved, clearlydefined
+npm/npmjs/-/ws/7.5.9, MIT, approved, #1940
+npm/npmjs/-/ws/8.12.0, MIT, approved, clearlydefined
+npm/npmjs/-/xml-name-validator/3.0.0, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/xmlchars/2.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/xtend/4.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/y18n/5.0.8, ISC, approved, clearlydefined
+npm/npmjs/-/yallist/3.1.1, ISC, approved, clearlydefined
+npm/npmjs/-/yallist/4.0.0, ISC, approved, clearlydefined
+npm/npmjs/-/yaml/1.10.2, ISC, approved, clearlydefined
+npm/npmjs/-/yargs-parser/20.2.9, ISC, approved, clearlydefined
+npm/npmjs/-/yargs/16.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/yocto-queue/0.1.0, MIT, approved, clearlydefined
+npm/npmjs/@adobe/css-tools/4.1.0, MIT, approved, #6677
+npm/npmjs/@ampproject/remapping/2.2.0, Apache-2.0, approved, clearlydefined
+npm/npmjs/@apideck/better-ajv-errors/0.3.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/code-frame/7.12.11, MIT, approved, clearlydefined
+npm/npmjs/@babel/code-frame/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/compat-data/7.20.14, MIT, approved, #4653
+npm/npmjs/@babel/core/7.20.12, MIT, approved, #4666
+npm/npmjs/@babel/eslint-parser/7.19.1, MIT, approved, clearlydefined
+npm/npmjs/@babel/generator/7.20.14, MIT, approved, #4572
+npm/npmjs/@babel/helper-annotate-as-pure/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/helper-builder-binary-assignment-operator-visitor/7.18.9, MIT, approved, clearlydefined
+npm/npmjs/@babel/helper-compilation-targets/7.20.7, MIT AND BSD-2-Clause AND BSD-3-Clause, approved, #5989
+npm/npmjs/@babel/helper-create-class-features-plugin/7.20.12, MIT, approved, #4579
+npm/npmjs/@babel/helper-create-regexp-features-plugin/7.20.5, MIT, approved, clearlydefined
+npm/npmjs/@babel/helper-define-polyfill-provider/0.3.3, MIT, approved, clearlydefined
+npm/npmjs/@babel/helper-environment-visitor/7.18.9, MIT, approved, clearlydefined
+npm/npmjs/@babel/helper-explode-assignable-expression/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/helper-function-name/7.19.0, MIT, approved, clearlydefined
+npm/npmjs/@babel/helper-hoist-variables/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/helper-member-expression-to-functions/7.20.7, MIT AND BSD-2-Clause AND BSD-3-Clause, approved, #5986
+npm/npmjs/@babel/helper-module-imports/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/helper-module-transforms/7.20.11, MIT, approved, #4659
+npm/npmjs/@babel/helper-optimise-call-expression/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/helper-plugin-utils/7.20.2, MIT, approved, #4627
+npm/npmjs/@babel/helper-remap-async-to-generator/7.18.9, MIT, approved, clearlydefined
+npm/npmjs/@babel/helper-replace-supers/7.20.7, BSD-2-Clause AND MIT, approved, #5992
+npm/npmjs/@babel/helper-simple-access/7.20.2, MIT, approved, #4672
+npm/npmjs/@babel/helper-skip-transparent-expression-wrappers/7.20.0, MIT, approved, clearlydefined
+npm/npmjs/@babel/helper-split-export-declaration/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/helper-string-parser/7.19.4, MIT, approved, clearlydefined
+npm/npmjs/@babel/helper-validator-identifier/7.19.1, MIT, approved, clearlydefined
+npm/npmjs/@babel/helper-validator-option/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/helper-wrap-function/7.20.5, MIT, approved, clearlydefined
+npm/npmjs/@babel/helpers/7.20.13, MIT, approved, #4646
+npm/npmjs/@babel/highlight/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/parser/7.20.15, MIT, approved, #4604
+npm/npmjs/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.20.7, MIT AND BSD-2-Clause AND BSD-3-Clause, approved, #5987
+npm/npmjs/@babel/plugin-proposal-async-generator-functions/7.20.7, MIT, approved, #4607
+npm/npmjs/@babel/plugin-proposal-class-properties/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-proposal-class-static-block/7.20.7, MIT AND BSD-3-Clause AND BSD-2-Clause, approved, #5980
+npm/npmjs/@babel/plugin-proposal-decorators/7.20.13, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-proposal-dynamic-import/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-proposal-export-namespace-from/7.18.9, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-proposal-json-strings/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-proposal-logical-assignment-operators/7.20.7, BSD-2-Clause AND MIT, approved, #5991
+npm/npmjs/@babel/plugin-proposal-nullish-coalescing-operator/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-proposal-numeric-separator/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-proposal-object-rest-spread/7.20.7, MIT, approved, #4581
+npm/npmjs/@babel/plugin-proposal-optional-catch-binding/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-proposal-optional-chaining/7.20.7, MIT, approved, #5981
+npm/npmjs/@babel/plugin-proposal-private-methods/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-proposal-private-property-in-object/7.20.5, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-proposal-unicode-property-regex/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-async-generators/7.8.4, MIT, approved, #1973
+npm/npmjs/@babel/plugin-syntax-bigint/7.8.3, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-class-properties/7.12.13, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-class-static-block/7.14.5, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-decorators/7.19.0, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-dynamic-import/7.8.3, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-export-namespace-from/7.8.3, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-flow/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-import-assertions/7.20.0, MIT, approved, #4644
+npm/npmjs/@babel/plugin-syntax-import-meta/7.10.4, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-json-strings/7.8.3, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-jsx/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-logical-assignment-operators/7.10.4, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-nullish-coalescing-operator/7.8.3, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-numeric-separator/7.10.4, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-object-rest-spread/7.8.3, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-optional-catch-binding/7.8.3, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-optional-chaining/7.8.3, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-private-property-in-object/7.14.5, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-top-level-await/7.14.5, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-syntax-typescript/7.20.0, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-arrow-functions/7.20.7, MIT AND BSD-2-Clause AND MIT AND BSD-3-Clause, approved, #5990
+npm/npmjs/@babel/plugin-transform-async-to-generator/7.20.7, MIT AND BSD-3-Clause AND BSD-2-Clause, approved, #6230
+npm/npmjs/@babel/plugin-transform-block-scoped-functions/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-block-scoping/7.20.15, MIT, approved, #4641
+npm/npmjs/@babel/plugin-transform-classes/7.20.7, MIT, approved, #4670
+npm/npmjs/@babel/plugin-transform-computed-properties/7.20.7, MIT AND BSD-2-Clause AND BSD-3-Clause, approved, #5984
+npm/npmjs/@babel/plugin-transform-destructuring/7.20.7, MIT, approved, #4662
+npm/npmjs/@babel/plugin-transform-dotall-regex/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-duplicate-keys/7.18.9, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-exponentiation-operator/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-flow-strip-types/7.19.0, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-for-of/7.18.8, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-function-name/7.18.9, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-literals/7.18.9, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-member-expression-literals/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-modules-amd/7.20.11, MIT AND BSD-3-Clause AND BSD-2-Clause, approved, #6011
+npm/npmjs/@babel/plugin-transform-modules-commonjs/7.20.11, MIT AND BSD-3-Clause AND BSD-2-Clause, approved, #6012
+npm/npmjs/@babel/plugin-transform-modules-systemjs/7.20.11, MIT AND BSD-3-Clause AND BSD-2-Clause, approved, #6008
+npm/npmjs/@babel/plugin-transform-modules-umd/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-named-capturing-groups-regex/7.20.5, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-new-target/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-object-super/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-parameters/7.20.7, MIT, approved, #4590
+npm/npmjs/@babel/plugin-transform-property-literals/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-react-constant-elements/7.20.2, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-react-display-name/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-react-jsx-development/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-react-jsx/7.20.13, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-react-pure-annotations/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-regenerator/7.20.5, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-reserved-words/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-runtime/7.19.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-shorthand-properties/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-spread/7.20.7, BSD-2-Clause AND MIT, approved, #5982
+npm/npmjs/@babel/plugin-transform-sticky-regex/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-template-literals/7.18.9, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-typeof-symbol/7.18.9, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-typescript/7.20.13, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-unicode-escapes/7.18.10, MIT, approved, clearlydefined
+npm/npmjs/@babel/plugin-transform-unicode-regex/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/preset-env/7.20.2, MIT, approved, #4588
+npm/npmjs/@babel/preset-modules/0.1.5, MIT, approved, clearlydefined
+npm/npmjs/@babel/preset-react/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/preset-typescript/7.18.6, MIT, approved, clearlydefined
+npm/npmjs/@babel/runtime/7.20.13, MIT AND BSD-3-Clause AND BSD-2-Clause, approved, #6242
+npm/npmjs/@babel/runtime/7.21.0, MIT AND (BSD-2-Clause AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #7349
+npm/npmjs/@babel/template/7.20.7, MIT AND BSD-2-Clause AND BSD-3-Clause, approved, #5988
+npm/npmjs/@babel/traverse/7.20.13, MIT, approved, #4570
+npm/npmjs/@babel/types/7.20.7, MIT, approved, #4626
+npm/npmjs/@bcoe/v8-coverage/0.2.3, ISC AND MIT, approved, clearlydefined
+npm/npmjs/@csstools/normalize.css/12.0.0, CC0-1.0, approved, clearlydefined
+npm/npmjs/@csstools/postcss-cascade-layers/1.1.1, CC0-1.0, approved, clearlydefined
+npm/npmjs/@csstools/postcss-color-function/1.1.1, CC0-1.0 AND (MIT AND W3C-20150513) AND W3C-20150513 AND MIT, approved, #3022
+npm/npmjs/@csstools/postcss-font-format-keywords/1.0.1, CC0-1.0, approved, clearlydefined
+npm/npmjs/@csstools/postcss-hwb-function/1.0.2, CC0-1.0, approved, clearlydefined
+npm/npmjs/@csstools/postcss-ic-unit/1.0.1, CC0-1.0, approved, clearlydefined
+npm/npmjs/@csstools/postcss-is-pseudo-class/2.0.7, CC0-1.0, approved, clearlydefined
+npm/npmjs/@csstools/postcss-nested-calc/1.0.0, CC0-1.0, approved, clearlydefined
+npm/npmjs/@csstools/postcss-normalize-display-values/1.0.1, CC0-1.0, approved, clearlydefined
+npm/npmjs/@csstools/postcss-oklab-function/1.1.1, CC0-1.0 AND (MIT AND W3C-20150513) AND W3C-20150513 AND MIT, approved, #3026
+npm/npmjs/@csstools/postcss-progressive-custom-properties/1.3.0, CC0-1.0, approved, clearlydefined
+npm/npmjs/@csstools/postcss-stepped-value-functions/1.0.1, CC0-1.0, approved, clearlydefined
+npm/npmjs/@csstools/postcss-text-decoration-shorthand/1.0.0, CC0-1.0, approved, clearlydefined
+npm/npmjs/@csstools/postcss-trigonometric-functions/1.0.2, CC0-1.0, approved, clearlydefined
+npm/npmjs/@csstools/postcss-unset-value/1.0.2, CC0-1.0, approved, clearlydefined
+npm/npmjs/@csstools/selector-specificity/2.1.1, CC0-1.0, approved, #7043
+npm/npmjs/@emotion/babel-plugin/11.10.6, MIT, approved, #7345
+npm/npmjs/@emotion/cache/11.10.5, MIT, approved, clearlydefined
+npm/npmjs/@emotion/hash/0.9.0, MIT, approved, #8394
+npm/npmjs/@emotion/is-prop-valid/1.2.0, MIT, approved, #8392
+npm/npmjs/@emotion/memoize/0.8.0, MIT, approved, #8408
+npm/npmjs/@emotion/react/11.10.6, MIT AND (BSD-3-Clause AND MIT), approved, #3236
+npm/npmjs/@emotion/serialize/1.1.1, MIT, approved, #8417
+npm/npmjs/@emotion/sheet/1.2.1, MIT, approved, #8389
+npm/npmjs/@emotion/styled/11.10.6, MIT, approved, #7347
+npm/npmjs/@emotion/stylis/0.8.5, MIT, approved, clearlydefined
+npm/npmjs/@emotion/unitless/0.7.5, MIT, approved, clearlydefined
+npm/npmjs/@emotion/unitless/0.8.0, MIT, approved, #8403
+npm/npmjs/@emotion/use-insertion-effect-with-fallbacks/1.0.0, MIT, approved, #8419
+npm/npmjs/@emotion/utils/1.2.0, MIT, approved, #8415
+npm/npmjs/@emotion/weak-memoize/0.3.0, MIT, approved, #8402
+npm/npmjs/@eslint/eslintrc/0.4.3, MIT, approved, clearlydefined
+npm/npmjs/@eslint/eslintrc/1.4.1, MIT, approved, #5909
+npm/npmjs/@humanwhocodes/config-array/0.11.8, Apache-2.0, approved, #5876
+npm/npmjs/@humanwhocodes/config-array/0.5.0, Apache-2.0, approved, clearlydefined
+npm/npmjs/@humanwhocodes/module-importer/1.0.1, Apache-2.0, approved, clearlydefined
+npm/npmjs/@humanwhocodes/object-schema/1.2.1, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/@istanbuljs/load-nyc-config/1.1.0, ISC, approved, clearlydefined
+npm/npmjs/@istanbuljs/schema/0.1.3, MIT, approved, clearlydefined
+npm/npmjs/@jest/console/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/@jest/console/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/@jest/core/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/@jest/environment/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/@jest/expect-utils/29.4.1, MIT, approved, clearlydefined
+npm/npmjs/@jest/fake-timers/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/@jest/globals/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/@jest/reporters/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/@jest/schemas/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/@jest/schemas/29.4.0, MIT, approved, clearlydefined
+npm/npmjs/@jest/source-map/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/@jest/test-result/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/@jest/test-result/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/@jest/test-sequencer/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/@jest/transform/27.5.1, MIT, approved, clearlydefined
+npm/npmjs/@jest/types/27.5.1, 0BSD AND Apache-2.0 AND BSD-2-Clause AND MIT, approved, #1960
+npm/npmjs/@jest/types/28.1.3, MIT, approved, clearlydefined
+npm/npmjs/@jest/types/29.4.1, MIT, approved, clearlydefined
+npm/npmjs/@jridgewell/gen-mapping/0.1.1, MIT, approved, clearlydefined
+npm/npmjs/@jridgewell/gen-mapping/0.3.2, MIT, approved, clearlydefined
+npm/npmjs/@jridgewell/resolve-uri/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/@jridgewell/set-array/1.1.2, MIT, approved, clearlydefined
+npm/npmjs/@jridgewell/source-map/0.3.2, MIT, approved, clearlydefined
+npm/npmjs/@jridgewell/sourcemap-codec/1.4.14, MIT, approved, clearlydefined
+npm/npmjs/@jridgewell/trace-mapping/0.3.17, MIT, approved, clearlydefined
+npm/npmjs/@leichtgewicht/ip-codec/2.0.4, MIT, approved, clearlydefined
+npm/npmjs/@mui/base/5.0.0-alpha.118, MIT, approved, #2992
+npm/npmjs/@mui/core-downloads-tracker/5.11.9, MIT, approved, #7908
+npm/npmjs/@mui/material/5.11.10, , approved, #7346
+npm/npmjs/@mui/private-theming/5.11.9, MIT AND OFL-1.1 AND CC-BY-3.0, approved, #6629
+npm/npmjs/@mui/styled-engine/5.11.9, MIT AND OFL-1.1 AND CC-BY-3.0, approved, #6642
+npm/npmjs/@mui/system/5.11.9, MIT AND OFL-1.1 AND CC-BY-3.0, approved, #6627
+npm/npmjs/@mui/types/7.2.3, MIT, approved, clearlydefined
+npm/npmjs/@mui/utils/5.11.9, MIT AND OFL-1.1 AND CC-BY-3.0, approved, #6632
+npm/npmjs/@nicolo-ribaudo/eslint-scope-5-internals/5.1.1-v1, MIT, approved, clearlydefined
+npm/npmjs/@nodelib/fs.scandir/2.1.5, MIT, approved, clearlydefined
+npm/npmjs/@nodelib/fs.stat/2.0.5, MIT, approved, clearlydefined
+npm/npmjs/@nodelib/fs.walk/1.2.8, MIT, approved, clearlydefined
+npm/npmjs/@pmmmwh/react-refresh-webpack-plugin/0.5.10, MIT, approved, clearlydefined
+npm/npmjs/@popperjs/core/2.11.6, MIT, approved, clearlydefined
+npm/npmjs/@react-aria/ssr/3.4.1, Apache-2.0, approved, clearlydefined
+npm/npmjs/@reduxjs/toolkit/1.9.2, MIT AND (BSD-2-Clause AND MIT) AND Apache-2.0, approved, #7050
+npm/npmjs/@restart/hooks/0.4.8, MIT, approved, #7049
+npm/npmjs/@restart/ui/1.5.4, MIT, approved, #7051
+npm/npmjs/@rollup/plugin-babel/5.3.1, MIT, approved, clearlydefined
+npm/npmjs/@rollup/plugin-node-resolve/11.2.1, MIT, approved, clearlydefined
+npm/npmjs/@rollup/plugin-replace/2.4.2, MIT, approved, clearlydefined
+npm/npmjs/@rollup/pluginutils/3.1.0, MIT, approved, clearlydefined
+npm/npmjs/@rushstack/eslint-patch/1.2.0, MIT, approved, clearlydefined
+npm/npmjs/@sinclair/typebox/0.24.51, MIT, approved, #3330
+npm/npmjs/@sinclair/typebox/0.25.21, MIT, approved, clearlydefined
+npm/npmjs/@sinonjs/commons/1.8.6, BSD-3-Clause, approved, #4340
+npm/npmjs/@sinonjs/fake-timers/8.1.0, BSD-3-Clause, approved, #2563
+npm/npmjs/@surma/rollup-plugin-off-main-thread/2.2.3, Apache-2.0, approved, #3006
+npm/npmjs/@svgr/babel-plugin-add-jsx-attribute/5.4.0, MIT, approved, clearlydefined
+npm/npmjs/@svgr/babel-plugin-remove-jsx-attribute/5.4.0, MIT, approved, clearlydefined
+npm/npmjs/@svgr/babel-plugin-remove-jsx-empty-expression/5.0.1, MIT, approved, clearlydefined
+npm/npmjs/@svgr/babel-plugin-replace-jsx-attribute-value/5.0.1, MIT, approved, clearlydefined
+npm/npmjs/@svgr/babel-plugin-svg-dynamic-title/5.4.0, MIT, approved, clearlydefined
+npm/npmjs/@svgr/babel-plugin-svg-em-dimensions/5.4.0, MIT, approved, clearlydefined
+npm/npmjs/@svgr/babel-plugin-transform-react-native-svg/5.4.0, MIT, approved, clearlydefined
+npm/npmjs/@svgr/babel-plugin-transform-svg-component/5.5.0, MIT, approved, clearlydefined
+npm/npmjs/@svgr/babel-preset/5.5.0, MIT, approved, clearlydefined
+npm/npmjs/@svgr/core/5.5.0, MIT, approved, clearlydefined
+npm/npmjs/@svgr/hast-util-to-babel-ast/5.5.0, MIT, approved, clearlydefined
+npm/npmjs/@svgr/plugin-jsx/5.5.0, MIT, approved, clearlydefined
+npm/npmjs/@svgr/plugin-svgo/5.5.0, MIT, approved, clearlydefined
+npm/npmjs/@svgr/webpack/5.5.0, MIT, approved, clearlydefined
+npm/npmjs/@swc/helpers/0.4.14, MIT, approved, clearlydefined
+npm/npmjs/@testing-library/dom/8.20.0, MIT, approved, #6929
+npm/npmjs/@testing-library/jest-dom/5.16.5, MIT, approved, clearlydefined
+npm/npmjs/@testing-library/react/13.4.0, MIT, approved, #3261
+npm/npmjs/@testing-library/user-event/13.5.0, MIT, approved, clearlydefined
+npm/npmjs/@tootallnate/once/1.1.2, MIT, approved, clearlydefined
+npm/npmjs/@trysound/sax/0.2.0, ISC, approved, clearlydefined
+npm/npmjs/@types/aria-query/5.0.1, MIT, approved, clearlydefined
+npm/npmjs/@types/babel__core/7.20.0, MIT, approved, clearlydefined
+npm/npmjs/@types/babel__generator/7.6.4, MIT, approved, clearlydefined
+npm/npmjs/@types/babel__template/7.4.1, MIT, approved, clearlydefined
+npm/npmjs/@types/babel__traverse/7.18.3, MIT, approved, clearlydefined
+npm/npmjs/@types/body-parser/1.19.2, MIT, approved, clearlydefined
+npm/npmjs/@types/bonjour/3.5.10, MIT, approved, clearlydefined
+npm/npmjs/@types/connect-history-api-fallback/1.3.5, MIT, approved, clearlydefined
+npm/npmjs/@types/connect/3.4.35, MIT, approved, clearlydefined
+npm/npmjs/@types/eslint-scope/3.7.4, MIT, approved, clearlydefined
+npm/npmjs/@types/eslint/8.21.0, MIT, approved, #7047
+npm/npmjs/@types/estree/0.0.39, MIT, approved, clearlydefined
+npm/npmjs/@types/estree/0.0.51, MIT, approved, clearlydefined
+npm/npmjs/@types/estree/1.0.0, MIT, approved, #8266
+npm/npmjs/@types/express-serve-static-core/4.17.33, MIT, approved, #6020
+npm/npmjs/@types/express/4.17.17, MIT, approved, #5760
+npm/npmjs/@types/graceful-fs/4.1.6, MIT, approved, clearlydefined
+npm/npmjs/@types/history/4.7.11, MIT, approved, clearlydefined
+npm/npmjs/@types/hoist-non-react-statics/3.3.1, MIT, approved, clearlydefined
+npm/npmjs/@types/html-minifier-terser/6.1.0, MIT, approved, clearlydefined
+npm/npmjs/@types/http-proxy/1.17.9, MIT, approved, #8414
+npm/npmjs/@types/istanbul-lib-coverage/2.0.4, MIT, approved, clearlydefined
+npm/npmjs/@types/istanbul-lib-report/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/@types/istanbul-reports/3.0.1, MIT, approved, clearlydefined
+npm/npmjs/@types/jest/27.5.2, MIT, approved, clearlydefined
+npm/npmjs/@types/jest/29.4.0, MIT, approved, #7048
+npm/npmjs/@types/json-schema/7.0.11, MIT, approved, clearlydefined
+npm/npmjs/@types/json5/0.0.29, MIT, approved, clearlydefined
+npm/npmjs/@types/mime/3.0.1, MIT, approved, clearlydefined
+npm/npmjs/@types/node/17.0.45, MIT, approved, clearlydefined
+npm/npmjs/@types/node/18.11.19, MIT, approved, #5746
+npm/npmjs/@types/parse-json/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/@types/prettier/2.7.2, MIT, approved, #9030
+npm/npmjs/@types/prop-types/15.7.5, MIT, approved, clearlydefined
+npm/npmjs/@types/q/1.5.5, MIT, approved, clearlydefined
+npm/npmjs/@types/qs/6.9.7, MIT, approved, clearlydefined
+npm/npmjs/@types/range-parser/1.2.4, MIT, approved, clearlydefined
+npm/npmjs/@types/react-dom/18.0.10, MIT, approved, #4598
+npm/npmjs/@types/react-is/17.0.3, MIT, approved, #8424
+npm/npmjs/@types/react-redux/7.1.25, MIT, approved, clearlydefined
+npm/npmjs/@types/react-router-dom/5.3.3, MIT, approved, clearlydefined
+npm/npmjs/@types/react-router/5.1.20, MIT, approved, clearlydefined
+npm/npmjs/@types/react-transition-group/4.4.5, MIT, approved, #8416
+npm/npmjs/@types/react/18.0.27, MIT, approved, #4609
+npm/npmjs/@types/redux-actions/2.6.2, MIT, approved, clearlydefined
+npm/npmjs/@types/resolve/1.17.1, MIT, approved, clearlydefined
+npm/npmjs/@types/retry/0.12.0, MIT, approved, clearlydefined
+npm/npmjs/@types/scheduler/0.16.2, MIT, approved, #7582
+npm/npmjs/@types/semver/7.3.13, MIT, approved, #4668
+npm/npmjs/@types/serve-index/1.9.1, MIT, approved, clearlydefined
+npm/npmjs/@types/serve-static/1.15.0, None, restricted, #9186
+npm/npmjs/@types/sockjs/0.3.33, MIT, approved, clearlydefined
+npm/npmjs/@types/stack-utils/2.0.1, MIT, approved, clearlydefined
+npm/npmjs/@types/testing-library__jest-dom/5.14.5, MIT, approved, clearlydefined
+npm/npmjs/@types/trusted-types/2.0.2, MIT, approved, clearlydefined
+npm/npmjs/@types/warning/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/@types/ws/8.5.4, MIT, approved, #6016
+npm/npmjs/@types/yargs-parser/21.0.0, MIT, approved, clearlydefined
+npm/npmjs/@types/yargs/16.0.5, MIT, approved, clearlydefined
+npm/npmjs/@types/yargs/17.0.22, MIT, approved, #7054
+npm/npmjs/@typescript-eslint/eslint-plugin/5.51.0, BSD-2-Clause AND MIT, approved, #7055
+npm/npmjs/@typescript-eslint/experimental-utils/5.51.0, BSD-2-Clause AND MIT, approved, #7053
+npm/npmjs/@typescript-eslint/parser/5.51.0, BSD-2-Clause AND MIT, approved, #7052
+npm/npmjs/@typescript-eslint/scope-manager/5.51.0, BSD-2-Clause AND MIT, approved, #7056
+npm/npmjs/@typescript-eslint/type-utils/5.51.0, BSD-2-Clause AND MIT, approved, #7061
+npm/npmjs/@typescript-eslint/types/5.51.0, BSD-2-Clause AND MIT, approved, #7059
+npm/npmjs/@typescript-eslint/typescript-estree/5.51.0, BSD-2-Clause AND MIT, approved, #7057
+npm/npmjs/@typescript-eslint/utils/5.51.0, BSD-2-Clause AND MIT, approved, #7058
+npm/npmjs/@typescript-eslint/visitor-keys/5.51.0, BSD-2-Clause AND MIT, approved, #7060
+npm/npmjs/@webassemblyjs/ast/1.11.1, MIT, approved, #7953
+npm/npmjs/@webassemblyjs/floating-point-hex-parser/1.11.1, MIT, approved, #7959
+npm/npmjs/@webassemblyjs/helper-api-error/1.11.1, MIT, approved, #7969
+npm/npmjs/@webassemblyjs/helper-buffer/1.11.1, MIT, approved, #7955
+npm/npmjs/@webassemblyjs/helper-numbers/1.11.1, MIT, approved, #7954
+npm/npmjs/@webassemblyjs/helper-wasm-bytecode/1.11.1, MIT, approved, #7962
+npm/npmjs/@webassemblyjs/helper-wasm-section/1.11.1, MIT, approved, #7960
+npm/npmjs/@webassemblyjs/ieee754/1.11.1, MIT, approved, #7961
+npm/npmjs/@webassemblyjs/leb128/1.11.1, Apache-2.0, approved, #7958
+npm/npmjs/@webassemblyjs/utf8/1.11.1, MIT, approved, #7966
+npm/npmjs/@webassemblyjs/wasm-edit/1.11.1, Apache-2.0 AND ISC AND MIT, approved, #2186
+npm/npmjs/@webassemblyjs/wasm-gen/1.11.1, MIT, approved, #7964
+npm/npmjs/@webassemblyjs/wasm-opt/1.11.1, MIT, approved, #7967
+npm/npmjs/@webassemblyjs/wasm-parser/1.11.1, MIT, approved, #7965
+npm/npmjs/@webassemblyjs/wast-printer/1.11.1, MIT, approved, #7957
+npm/npmjs/@xtuc/ieee754/1.2.0, BSD-3-Clause, approved, #123
+npm/npmjs/@xtuc/long/4.2.2, Apache-2.0, approved, clearlydefined

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1292,7 +1292,7 @@ npm/npmjs/@types/retry/0.12.0, MIT, approved, clearlydefined
 npm/npmjs/@types/scheduler/0.16.2, MIT, approved, #7582
 npm/npmjs/@types/semver/7.3.13, MIT, approved, #4668
 npm/npmjs/@types/serve-index/1.9.1, MIT, approved, clearlydefined
-npm/npmjs/@types/serve-static/1.15.0, None, restricted, #9186
+npm/npmjs/@types/serve-static/1.15.0, MIT, approved, #9188
 npm/npmjs/@types/sockjs/0.3.33, MIT, approved, clearlydefined
 npm/npmjs/@types/stack-utils/2.0.1, MIT, approved, clearlydefined
 npm/npmjs/@types/testing-library__jest-dom/5.14.5, MIT, approved, clearlydefined

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -22,12 +22,13 @@ SPDX-License-Identifier: Apache-2.0
 
 The project maintains the following source code repositories in the GitHub organization https://github.com/eclipse-tractusx:
 
-* https://github.com/eclipse-tractusx/portal-frontend-registration
-* https://github.com/eclipse-tractusx/portal-frontend
-* https://github.com/eclipse-tractusx/portal-backend
-* https://github.com/eclipse-tractusx/portal-assets
-* https://github.com/eclipse-tractusx/portal-cd
-* https://github.com/eclipse-tractusx/portal-iam
+- https://github.com/eclipse-tractusx/portal-frontend-registration
+- https://github.com/eclipse-tractusx/portal-frontend
+- https://github.com/eclipse-tractusx/portal-shared-components
+- https://github.com/eclipse-tractusx/portal-backend
+- https://github.com/eclipse-tractusx/portal-assets
+- https://github.com/eclipse-tractusx/portal-cd
+- https://github.com/eclipse-tractusx/portal-iam
 
 ## Third-party Content
 

--- a/scripts/check-dependencies.md
+++ b/scripts/check-dependencies.md
@@ -1,0 +1,9 @@
+# Check dependencies
+
+Dependencies are checked by the [Eclipse Dash License Tool](https://github.com/eclipse/dash-licenses) with a GitHub workflow (dependencies.yaml).
+
+This workflow uses the executable jar in the download directory.
+
+In order to update the executable jar run the following command from the root directory:
+
+    curl -L --output ./scripts/download/org.eclipse.dash.licenses-1.0.2.jar 'https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=1.0.2'


### PR DESCRIPTION
## Description

- add workflow to check 3rd party dependencies with the [Eclipse Dash License Tool](https://github.com/eclipse/dash-licenses)
- change dependencies file to '-summary' format from Dash Tool

**Due to the new format in the dependencies file: once this PR is merged into dev, all open feature branches should be rebased to dev, as the dependencies check will fail otherwise.**

- skip dispatch to portal-cd for hotfix in the release workflow
- update notice file

## Why

Dependencies check should be automated
Hotfix scenario not yet covered by release workflow
Notice file needs to be update due to new shared components repository

## Issue

n/a

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my own changes
- [x] I have successfully tested my changes locally