### PR TITLE
chore: update translations.json

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -302,7 +302,7 @@ npm/npmjs/-/find-up/4.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/find-up/5.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/flat-cache/3.0.4, MIT, approved, clearlydefined
 npm/npmjs/-/flatted/3.2.7, ISC AND (ISC AND MIT), approved, #2430
-npm/npmjs/-/follow-redirects/1.15.2, MIT, approved, clearlydefined
+npm/npmjs/-/follow-redirects/1.15.2, MIT, approved, #10782
 npm/npmjs/-/for-each/0.3.3, MIT, approved, clearlydefined
 npm/npmjs/-/fork-ts-checker-webpack-plugin/6.5.2, MIT, approved, #7487
 npm/npmjs/-/form-data/3.0.1, MIT, approved, clearlydefined
@@ -316,7 +316,7 @@ npm/npmjs/-/fs-monkey/1.0.3, Unlicense AND (ISC AND MIT), approved, #2964
 npm/npmjs/-/fs.realpath/1.0.0, ISC, approved, clearlydefined
 npm/npmjs/-/fsevents/2.3.2, MIT, approved, #2967
 npm/npmjs/-/function-bind/1.1.1, MIT, approved, clearlydefined
-npm/npmjs/-/function.prototype.name/1.1.5, MIT, approved, clearlydefined
+npm/npmjs/-/function.prototype.name/1.1.5, MIT, approved, #10255
 npm/npmjs/-/functional-red-black-tree/1.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/functions-have-names/1.2.3, MIT, approved, clearlydefined
 npm/npmjs/-/fuse.js/3.6.1, Apache-2.0, approved, clearlydefined
@@ -872,7 +872,7 @@ npm/npmjs/-/supports-color/8.1.1, MIT, approved, clearlydefined
 npm/npmjs/-/supports-hyperlinks/2.3.0, MIT, approved, clearlydefined
 npm/npmjs/-/supports-preserve-symlinks-flag/1.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/svg-parser/2.0.4, MIT, approved, clearlydefined
-npm/npmjs/-/svgo/1.3.2, MIT, approved, clearlydefined
+npm/npmjs/-/svgo/1.3.2, MIT AND Apache-2.0, approved, #10499
 npm/npmjs/-/svgo/2.8.0, MIT AND (0BSD AND BSD-2-Clause AND MIT) AND Apache-2.0, approved, #2989
 npm/npmjs/-/symbol-tree/3.2.4, MIT, approved, clearlydefined
 npm/npmjs/-/table/6.8.1, BSD-3-Clause, approved, #4596
@@ -1198,7 +1198,7 @@ npm/npmjs/@leichtgewicht/ip-codec/2.0.4, MIT, approved, clearlydefined
 npm/npmjs/@mui/base/5.0.0-alpha.118, MIT, approved, #2992
 npm/npmjs/@mui/core-downloads-tracker/5.11.9, MIT, approved, #7908
 npm/npmjs/@mui/icons-material/5.14.3, MIT AND CC-BY-3.0, approved, #9876
-npm/npmjs/@mui/material/5.11.10, , approved, #7346
+npm/npmjs/@mui/material/5.11.10, CC-BY-3.0 AND Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND Unlicense AND OFL-1.1, approved, #7346
 npm/npmjs/@mui/private-theming/5.11.9, MIT AND OFL-1.1 AND CC-BY-3.0, approved, #6629
 npm/npmjs/@mui/styled-engine/5.11.9, MIT AND OFL-1.1 AND CC-BY-3.0, approved, #6642
 npm/npmjs/@mui/system/5.11.9, MIT AND OFL-1.1 AND CC-BY-3.0, approved, #6627
@@ -1250,11 +1250,11 @@ npm/npmjs/@types/babel__core/7.20.0, MIT, approved, clearlydefined
 npm/npmjs/@types/babel__generator/7.6.4, MIT, approved, clearlydefined
 npm/npmjs/@types/babel__template/7.4.1, MIT, approved, clearlydefined
 npm/npmjs/@types/babel__traverse/7.18.3, MIT, approved, clearlydefined
-npm/npmjs/@types/body-parser/1.19.2, MIT, approved, clearlydefined
+npm/npmjs/@types/body-parser/1.19.2, MIT, approved, #10831
 npm/npmjs/@types/bonjour/3.5.10, MIT, approved, clearlydefined
 npm/npmjs/@types/connect-history-api-fallback/1.3.5, MIT, approved, clearlydefined
 npm/npmjs/@types/connect/3.4.35, MIT, approved, clearlydefined
-npm/npmjs/@types/eslint-scope/3.7.4, MIT, approved, clearlydefined
+npm/npmjs/@types/eslint-scope/3.7.4, MIT, approved, #10812
 npm/npmjs/@types/eslint/8.21.0, MIT, approved, #7047
 npm/npmjs/@types/estree/0.0.39, MIT, approved, clearlydefined
 npm/npmjs/@types/estree/0.0.51, MIT, approved, clearlydefined
@@ -1273,7 +1273,7 @@ npm/npmjs/@types/jest/27.5.2, MIT, approved, clearlydefined
 npm/npmjs/@types/jest/29.4.0, MIT, approved, #7048
 npm/npmjs/@types/json-schema/7.0.11, MIT, approved, clearlydefined
 npm/npmjs/@types/json5/0.0.29, MIT, approved, clearlydefined
-npm/npmjs/@types/mime/3.0.1, MIT, approved, clearlydefined
+npm/npmjs/@types/mime/3.0.1, MIT, approved, #10805
 npm/npmjs/@types/node/17.0.45, MIT, approved, clearlydefined
 npm/npmjs/@types/node/18.11.19, MIT, approved, #5746
 npm/npmjs/@types/parse-json/4.0.0, MIT, approved, clearlydefined
@@ -1281,7 +1281,7 @@ npm/npmjs/@types/prettier/2.7.2, MIT, approved, #9030
 npm/npmjs/@types/prop-types/15.7.5, MIT, approved, clearlydefined
 npm/npmjs/@types/q/1.5.5, MIT, approved, clearlydefined
 npm/npmjs/@types/qs/6.9.7, MIT, approved, clearlydefined
-npm/npmjs/@types/range-parser/1.2.4, MIT, approved, clearlydefined
+npm/npmjs/@types/range-parser/1.2.4, MIT, approved, #10795
 npm/npmjs/@types/react-dom/18.0.10, MIT, approved, #4598
 npm/npmjs/@types/react-is/17.0.3, MIT, approved, #8424
 npm/npmjs/@types/react-redux/7.1.25, MIT, approved, clearlydefined

--- a/src/locales/en/translations.json
+++ b/src/locales/en/translations.json
@@ -119,7 +119,7 @@
   "documentUpload": {
     "title": "Upload documents",
     "step": "4",
-    "subTitle": "Please upload your legal company commercial register document as well as the conformity approval (if app/service provider role was selected). /n Please ensure to upload a pdf document only with limited document size of < 8MB.",
+    "subTitle": "Please upload your legal company commercial register document as well as the conformity approval (if app/service provider role was selected). Please ensure to upload a pdf document only with limited document size of < 8MB.",
     "dragDropMessage": "Drag and drop files here, or click to select files",
     "dragDropCaption": "on your computer",
     "dragDropSpanCaption": "browse files",


### PR DESCRIPTION
## Description

Removed "/n" from the translation files

## Why

/n was used for line break and needed to get removed since the line break currently works with new translation key only

## Issue

Defect recognized in the testing phase

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
