### PR TITLE
build(arch): build images for arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Unit Tests
         run: yarn test:ci
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
@@ -79,6 +82,7 @@ jobs:
         with:
           context: .
           file: .conf/Dockerfile
+          platforms: linux/amd64, linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release-release_candidate.yml
+++ b/.github/workflows/release-release_candidate.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Unit Tests
         run: yarn test:ci
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
@@ -98,6 +101,7 @@ jobs:
         with:
           context: .
           file: .conf/Dockerfile
+          platforms: linux/amd64, linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Unit Tests
         run: yarn test:ci
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
@@ -99,6 +102,7 @@ jobs:
         with:
           context: .
           file: .conf/Dockerfile
+          platforms: linux/amd64, linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Unit Tests
         run: yarn test:ci
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
@@ -79,6 +82,7 @@ jobs:
         with:
           context: .
           file: .conf/Dockerfile
+          platforms: linux/amd64, linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -872,7 +872,7 @@ npm/npmjs/-/supports-color/8.1.1, MIT, approved, clearlydefined
 npm/npmjs/-/supports-hyperlinks/2.3.0, MIT, approved, clearlydefined
 npm/npmjs/-/supports-preserve-symlinks-flag/1.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/svg-parser/2.0.4, MIT, approved, clearlydefined
-npm/npmjs/-/svgo/1.3.2, MIT, approved, clearlydefined
+npm/npmjs/-/svgo/1.3.2, MIT AND Apache-2.0, approved, #10499
 npm/npmjs/-/svgo/2.8.0, MIT AND (0BSD AND BSD-2-Clause AND MIT) AND Apache-2.0, approved, #2989
 npm/npmjs/-/symbol-tree/3.2.4, MIT, approved, clearlydefined
 npm/npmjs/-/table/6.8.1, BSD-3-Clause, approved, #4596


### PR DESCRIPTION
## Description

build images also for arm64, in addition to amd64

## Why

enable localdev umbrella chart: arm64 images needed for usage on Mac

## Issue

[localdev](https://github.com/eclipse-tractusx/portal-cd/pull/90)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
