### PR TITLE
fix(vulnerability): upgrade axios dependency

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -51,7 +51,6 @@ npm/npmjs/-/attr-accept/2.2.2, MIT, approved, clearlydefined
 npm/npmjs/-/autoprefixer/10.4.16, MIT, approved, #7494
 npm/npmjs/-/available-typed-arrays/1.0.5, MIT, approved, clearlydefined
 npm/npmjs/-/axe-core/4.8.2, MPL-2.0 AND MIT AND (Apache-2.0 AND OFL-1.1), approved, #10969
-npm/npmjs/-/axios/0.27.2, MIT, approved, clearlydefined
 npm/npmjs/-/axios/1.6.1, MIT, approved, #11338
 npm/npmjs/-/axobject-query/3.2.1, Apache-2.0, approved, #9144
 npm/npmjs/-/babel-jest/27.5.1, MIT, approved, clearlydefined

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@reduxjs/toolkit": "^1.8.1",
     "@types/react-redux": "^7.1.22",
     "@types/redux-actions": "^2.6.2",
-    "axios": "^0.27.2",
+    "axios": "^1.6.1",
     "bootstrap": "^5.1.3",
     "history": "^4.10.1",
     "i18next": "^21.5.3",
@@ -59,7 +59,6 @@
     "**/tough-cookie": "^4.1.3",
     "**/webpack": "^5.76.0",
     "**/@babel/traverse": "^7.23.2",
-    "**/axios": "^1.6.1",
     "**/css-what": "^6.1.0"
   },
   "devDependencies": {

--- a/src/helpers/HttpClient.ts
+++ b/src/helpers/HttpClient.ts
@@ -21,8 +21,8 @@
 import axios, {
   AxiosError,
   AxiosInstance,
-  AxiosRequestHeaders,
   AxiosResponse,
+  RawAxiosRequestHeaders,
   ResponseType,
 } from 'axios'
 
@@ -42,7 +42,7 @@ export abstract class HttpClient {
     baseURL: string,
     reponseSuccessInterceptor = undefined,
     responseErrorInterceptor = undefined,
-    headers: AxiosRequestHeaders = {
+    headers: RawAxiosRequestHeaders = {
       'Content-Type': 'application/json',
     },
     timeout: number = Number.parseInt(

--- a/src/services/RequestService.ts
+++ b/src/services/RequestService.ts
@@ -18,17 +18,17 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { AxiosRequestHeaders, ResponseType } from 'axios'
+import { RawAxiosRequestHeaders, ResponseType } from 'axios'
 import UserService from './UserService'
 
-export const getHeaders = (): { headers: AxiosRequestHeaders } => ({
+export const getHeaders = (): { headers: RawAxiosRequestHeaders } => ({
   headers: {
     authorization: `Bearer ${UserService.getToken()}`,
   },
 })
 
 export const getBlobHeaders = (): {
-  headers: AxiosRequestHeaders
+  headers: RawAxiosRequestHeaders
   responseType: ResponseType
 } => ({
   headers: {

--- a/src/state/features/applicationDocuments/api.ts
+++ b/src/state/features/applicationDocuments/api.ts
@@ -22,7 +22,7 @@ import axios, { AxiosResponse, AxiosResponseHeaders } from 'axios'
 import { HttpClient } from '../../../helpers/HttpClient'
 import { getApiBase } from '../../../services/EnvironmentService'
 import RequestService from '../../../services/RequestService'
-import { PostDocumentType } from '../../../types/MainTypes'
+import { PostDocumentType, ProgressType } from '../../../types/MainTypes'
 
 export class Api extends HttpClient {
   private static classInstance?: Api

--- a/src/state/features/applicationDocuments/api.ts
+++ b/src/state/features/applicationDocuments/api.ts
@@ -22,7 +22,7 @@ import axios, { AxiosResponse, AxiosResponseHeaders } from 'axios'
 import { HttpClient } from '../../../helpers/HttpClient'
 import { getApiBase } from '../../../services/EnvironmentService'
 import RequestService from '../../../services/RequestService'
-import { PostDocumentType, ProgressType } from '../../../types/MainTypes'
+import { PostDocumentType } from '../../../types/MainTypes'
 
 export class Api extends HttpClient {
   private static classInstance?: Api

--- a/src/types/MainTypes.ts
+++ b/src/types/MainTypes.ts
@@ -50,7 +50,7 @@ export type FileStatusValue = 'done' | 'rejected_file_type' | 'error_file_size'
 
 export interface ProgressType {
   loaded: number
-  total: number
+  total?: number
 }
 
 export interface PostDocumentType {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3220,14 +3220,6 @@ axe-core@^4.6.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.8.2.tgz#2f6f3cde40935825cf4465e3c1c9e77b240ff6ae"
   integrity sha512-/dlp0fxyM3R8YW7MFzaHWXrf4zzbr0vaYb23VBFCl83R7nWNPg/yaQw2Dc8jzCMmDVLhSdzH8MjrsuIUuvX+6g==
 
-axios@^0.27.2:
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
-  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
-  dependencies:
-    follow-redirects "^1.14.9"
-    form-data "^4.0.0"
-
 axios@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.1.tgz#76550d644bf0a2d469a01f9244db6753208397d7"
@@ -5258,7 +5250,7 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.9, follow-redirects@^1.15.0:
+follow-redirects@^1.0.0, follow-redirects@^1.15.0:
   version "1.15.3"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
   integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==


### PR DESCRIPTION
## Description

 upgrade axios dependency from 0.27.2 to v1.6.1 and implement changes due to major version upgrade

## Why

due to vulnerability in previous version
https://github.com/eclipse-tractusx/portal-frontend-registration/pull/72 didn't solve the issue

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
