### PR TITLE
chore: remove references to consortia envs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ Link to Github issue.
 
 Please delete options that are not relevant.
 
-- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
+- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
 - [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
 - [ ] I have created and linked IP issues or requested their creation by a committer
 - [ ] I have performed a self-review of my own code

--- a/public/index.html
+++ b/public/index.html
@@ -33,7 +33,7 @@
     <div id="root" style='width:100%; height:100%'></div>
     <!-- Do NOT change 'ENV' without changing 'custom_env_vars_anchor' in scripts/inject-dynamic-env.sh as well -->
     <script>
-      const ENV = {PORTAL_ASSETS_URL:"http://localhost:3000/assets",PORTAL_BACKEND_URL:"https://portal-backend.dev.demo.catena-x.net",CENTRALIDP_URL:"https://centralidp.dev.demo.catena-x.net/auth",}
+      const ENV = {PORTAL_ASSETS_URL:"http://localhost:3000/assets",PORTAL_BACKEND_URL:"https://portal-backend.example.org",CENTRALIDP_URL:"https://centralidp.example.org/auth"}
     </script>
   </body>
 

--- a/scripts/inject-dynamic-env.sh
+++ b/scripts/inject-dynamic-env.sh
@@ -20,7 +20,7 @@
 ###############################################################
 
 custom_env_vars='{PORTAL_ASSETS_URL:"'$PORTAL_ASSETS_URL'",PORTAL_BACKEND_URL:"'$PORTAL_BACKEND_URL'",CENTRALIDP_URL:"'$CENTRALIDP_URL'"}'
-custom_env_vars_anchor='{PORTAL_ASSETS_URL:"http://localhost:3000/assets",PORTAL_BACKEND_URL:"https://portal-backend.dev.demo.catena-x.net",CENTRALIDP_URL:"https://centralidp.dev.demo.catena-x.net/auth"}'
+custom_env_vars_anchor='{PORTAL_ASSETS_URL:"http://localhost:3000/assets",PORTAL_BACKEND_URL:"https://portal-backend.example.org",CENTRALIDP_URL:"https://centralidp.example.org/auth"}'
 index_html_reference=`cat /usr/share/nginx/html/index.html.reference`
 index_html=${index_html_reference//$custom_env_vars_anchor/$custom_env_vars}
 echo "$index_html" > /usr/share/nginx/html/index.html

--- a/src/components/cax-companyData.tsx
+++ b/src/components/cax-companyData.tsx
@@ -607,7 +607,7 @@ export const CompanyDataCax = () => {
           errors.identifierNumber !== ''
         }
         helpUrl={
-          '/documentation/?path=docs%2F01.+Onboarding%2F02.+Registration%2F02.+Add+Company+Data.md'
+          '/documentation/?path=user%2F01.+Onboarding%2F02.+Registration%2F02.+Add+Company+Data.md'
         }
       />
     </>

--- a/src/components/cax-companyRole.tsx
+++ b/src/components/cax-companyRole.tsx
@@ -276,7 +276,7 @@ export const CompanyRoleCax = () => {
         handleBackClick={() => backClick()}
         handleNextClick={() => nextClick()}
         helpUrl={
-          '/documentation/?path=docs%2F01.+Onboarding%2F02.+Registration%2F04.+Company+Role+%26+Consent.md'
+          '/documentation/?path=user%2F01.+Onboarding%2F02.+Registration%2F04.+Company+Role+%26+Consent.md'
         }
       />
     </>

--- a/src/components/cax-responsibilities.tsx
+++ b/src/components/cax-responsibilities.tsx
@@ -276,7 +276,7 @@ export const ResponsibilitiesCax = () => {
         handleBackClick={() => backClick()}
         handleNextClick={() => nextClick()}
         helpUrl={
-          '/documentation/?path=docs%2F01.+Onboarding%2F02.+Registration%2F03.+Add+Additional+User%28s%29.md'
+          '/documentation/?path=user%2F01.+Onboarding%2F02.+Registration%2F03.+Add+Additional+User%28s%29.md'
         }
       />
     </>

--- a/src/components/dragdrop.tsx
+++ b/src/components/dragdrop.tsx
@@ -249,7 +249,7 @@ export const DragDrop = () => {
         handleBackClick={() => backClick()}
         handleNextClick={() => nextClick()}
         helpUrl={
-          '/documentation/?path=docs%2F01.+Onboarding%2F02.+Registration%2F05.+Document+Upload.md'
+          '/documentation/?path=user%2F01.+Onboarding%2F02.+Registration%2F05.+Document+Upload.md'
         }
       />
     </>

--- a/src/components/finish.tsx
+++ b/src/components/finish.tsx
@@ -75,7 +75,7 @@ export const Finish = () => {
               <a
                 href={window.location.pathname.replace(
                   window.location.pathname,
-                  '/documentation/?path=docs%2F01.+Onboarding%2F02.+Registration%2F07.+FAQ.md#what-will-happen-after-the-registration'
+                  '/documentation/?path=user%2F01.+Onboarding%2F02.+Registration%2F07.+FAQ.md#what-will-happen-after-the-registration'
                 )}
                 target="_blank"
                 rel="noreferrer"

--- a/src/components/landing.tsx
+++ b/src/components/landing.tsx
@@ -90,7 +90,7 @@ export const Landing = () => {
                 target="_blank"
                 href={window.location.pathname.replace(
                   window.location.pathname,
-                  '/documentation/?path=docs%2F01.+Onboarding%2F02.+Registration'
+                  '/documentation/?path=user%2F01.+Onboarding%2F02.+Registration'
                 )}
               >
                 {' '}

--- a/src/components/verifyRegistration.tsx
+++ b/src/components/verifyRegistration.tsx
@@ -240,7 +240,7 @@ export const VerifyRegistration = () => {
         handleNextClick={() => nextClick()}
         tooltip={getTooltip()}
         helpUrl={
-          '/documentation/?path=docs%2F01.+Onboarding%2F02.+Registration%2F06.+Verify+Registration+Data.md'
+          '/documentation/?path=user%2F01.+Onboarding%2F02.+Registration%2F06.+Verify+Registration+Data.md'
         }
       />
     </>


### PR DESCRIPTION
## Description

- remove consortia dev env from default env settings for portal-backend and centralidp
- change docs links to new directory structure (and update pr template): introduced with eclipse-tractusx/portal-assets#226

## Why

https://github.com/eclipse-tractusx/portal-frontend/issues/445

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
