### PR TITLE
chore(trg-4-07): enable container for readOnlyRootFilesystem

### DIFF
--- a/.conf/Dockerfile
+++ b/.conf/Dockerfile
@@ -20,9 +20,12 @@
 FROM nginxinc/nginx-unprivileged:alpine
 COPY .conf/nginx.conf /etc/nginx/conf.d/default.conf
 COPY ./build /usr/share/nginx/html
-# Change to root user for renaming of index.html to index.html.reference, to be used by env variables inject script
+# Change to root user
 USER root
+# Rename index.html to index.html.reference, to be used by env variables inject script
 RUN mv /usr/share/nginx/html/index.html /usr/share/nginx/html/index.html.reference
+# Create symlink for tmp for index.html to enable readOnlyRootFilesystem
+RUN ln -s /tmp/index.html /usr/share/nginx/html/index.html
 # Add env variables inject script and mark as executable
 COPY ./scripts/inject-dynamic-env.sh /docker-entrypoint.d/00-inject-dynamic-env.sh
 RUN chmod +x /docker-entrypoint.d/00-inject-dynamic-env.sh
@@ -30,4 +33,5 @@ RUN chmod +x /docker-entrypoint.d/00-inject-dynamic-env.sh
 RUN apk update && apk add --no-cache bash
 # Make nginx owner of /usr/share/nginx/html/ and change to nginx user
 RUN chown -R 101:101 /usr/share/nginx/html/
+# Change to nginx user
 USER 101

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.6.0-RC4 (unreleased)
+
+### Change
+
+- enabled container for readOnlyRootFilesystem with symlink to tmp for index.html
+
 ## 1.6.0-RC3
 
 ### Change

--- a/scripts/inject-dynamic-env.sh
+++ b/scripts/inject-dynamic-env.sh
@@ -19,8 +19,13 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################
 
+# Define custom variable
 custom_env_vars='{PORTAL_ASSETS_URL:"'$PORTAL_ASSETS_URL'",PORTAL_BACKEND_URL:"'$PORTAL_BACKEND_URL'",CENTRALIDP_URL:"'$CENTRALIDP_URL'"}'
+# Define anchor variable
 custom_env_vars_anchor='{PORTAL_ASSETS_URL:"http://localhost:3000/assets",PORTAL_BACKEND_URL:"https://portal-backend.example.org",CENTRALIDP_URL:"https://centralidp.example.org/auth"}'
+# Read content of the reference index.html file into the index_html_reference variable
 index_html_reference=`cat /usr/share/nginx/html/index.html.reference`
+# Replace the anchor variable with the custom variable in the index.html file 
 index_html=${index_html_reference//$custom_env_vars_anchor/$custom_env_vars}
-echo "$index_html" > /usr/share/nginx/html/index.html
+# Write the modified index.html to tmp (to enable readOnlyRootFilesystem)
+echo "$index_html" > /tmp/index.html


### PR DESCRIPTION
## Description

- enable container for readOnlyRootFilesystem with symlink to tmp for index.html
- enhance comments in scripts

## Why

https://eclipse-tractusx.github.io/docs/release/trg-0/trg-4-07

## Issue

https://github.com/eclipse-tractusx/portal-cd/issues/159

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have commented my code, particularly in hard-to-understand areas
