### PR TITLE
fix(BPN Creation): Company region field regex modification

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -220,7 +220,7 @@ export const PATTERNS = {
   registeredNamePattern:
     /^[a-zA-ZÀ-ÿ\d][a-zA-ZÀ-ÿ\d !#'$@&%()*+,\-_./:;=<>?[\]\\^]{2,60}$/,
   streetHouseNumberPattern: /^[a-zÀ-ÿA-Z\d][a-zA-ZÀ-ÿ\d -]{2,60}$/,
-  regionPattern: /^[a-zA-Z0-9,"\s()']*$/,
+  regionPattern: /^[a-zA-Z0-9,"\s()'-]*$/,
   postalCodePattern: /^(?=[a-zA-Z\d]*[-\s]?[a-zA-Z\d]*$)[a-zA-Z\d-\s]{2,10}$/,
   countryPattern: /^[A-Za-zÀ-ÿ]{2,3}$/,
   IN: {


### PR DESCRIPTION
## Description

- fixed the company region field to accept the hyphens

## Why

Some regions, such as 'DE-BY', are not accepted in this field, which results in failure during BPN creation.

## Issue

https://github.com/eclipse-tractusx/portal-frontend-registration/issues/121

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
