### PR TITLE
chore(env): move values to config

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -33,7 +33,7 @@
     <div id="root" style='width:100%; height:100%'></div>
     <!-- Do NOT change 'ENV' without changing 'custom_env_vars_anchor' in scripts/inject-dynamic-env.sh as well -->
     <script>
-      const ENV = {PORTAL_ASSETS_URL:"http://localhost:3000/assets",PORTAL_BACKEND_URL:"https://portal-backend.example.org",CENTRALIDP_URL:"https://centralidp.example.org/auth"}
+      const ENV = {PORTAL_ASSETS_URL:"http://localhost:3000/assets",PORTAL_BACKEND_URL:"https://portal-backend.example.org",CENTRALIDP_URL:"https://centralidp.example.org/auth",REALM:"CX-Central",CLIENT_ID_REGISTRATION:"Cl1-CX-Registration"}
     </script>
   </body>
 

--- a/scripts/inject-dynamic-env.sh
+++ b/scripts/inject-dynamic-env.sh
@@ -20,9 +20,9 @@
 ###############################################################
 
 # Define custom variable
-custom_env_vars='{PORTAL_ASSETS_URL:"'$PORTAL_ASSETS_URL'",PORTAL_BACKEND_URL:"'$PORTAL_BACKEND_URL'",CENTRALIDP_URL:"'$CENTRALIDP_URL'"}'
+custom_env_vars='{PORTAL_ASSETS_URL:"'$PORTAL_ASSETS_URL'",PORTAL_BACKEND_URL:"'$PORTAL_BACKEND_URL'",CENTRALIDP_URL:"'$CENTRALIDP_URL'",REALM:"'$REALM'",CLIENT_ID_REGISTRATION:"'$CLIENT_ID_REGISTRATION'"}'
 # Define anchor variable
-custom_env_vars_anchor='{PORTAL_ASSETS_URL:"http://localhost:3000/assets",PORTAL_BACKEND_URL:"https://portal-backend.example.org",CENTRALIDP_URL:"https://centralidp.example.org/auth"}'
+custom_env_vars_anchor='{PORTAL_ASSETS_URL:"http://localhost:3000/assets",PORTAL_BACKEND_URL:"https://portal-backend.example.org",CENTRALIDP_URL:"https://centralidp.example.org/auth",REALM:"CX-Central",CLIENT_ID_REGISTRATION:"Cl1-CX-Registration"}'
 # Read content of the reference index.html file into the index_html_reference variable
 index_html_reference=`cat /usr/share/nginx/html/index.html.reference`
 # Replace the anchor variable with the custom variable in the index.html file 

--- a/src/services/EnvironmentService.ts
+++ b/src/services/EnvironmentService.ts
@@ -18,21 +18,24 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-declare const ENV: any
+declare const ENV: Record<string,string>
 
-export const getApiBase = () =>
-  typeof ENV === 'undefined' ? '' : ENV.PORTAL_BACKEND_URL
+export const getApiBase = () => ENV.PORTAL_BACKEND_URL ?? ''
 
-export const getAssetBase = () =>
-  typeof ENV === 'undefined' ? '' : ENV.PORTAL_ASSETS_URL
+export const getAssetBase = () => ENV.PORTAL_ASSETS_URL ?? ''
 
-export const getCentralIdp = () =>
-  typeof ENV === 'undefined' ? '' : ENV.CENTRALIDP_URL
+export const getCentralIdp = () => ENV.CENTRALIDP_URL ?? ''
+
+export const getRealm = () => ENV.REALM ?? ''
+
+export const getClientIdRegistration = () => ENV.CLIENT_ID_REGISTRATION ?? ''
 
 const EnvironmentService = {
+  getRealm,
+  getClientIdRegistration,
+  getCentralIdp,
   getApiBase,
   getAssetBase,
-  getCentralIdp,
 }
 
 export default EnvironmentService

--- a/src/services/UserService.js
+++ b/src/services/UserService.js
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { getCentralIdp } from './EnvironmentService'
+import { getCentralIdp, getClientIdRegistration, getRealm } from './EnvironmentService'
 import Keycloak from 'keycloak-js'
 
 const searchParams = new URLSearchParams(window.location.search)
@@ -27,7 +27,7 @@ if (!realm) {
   realm = localStorage.getItem('company')
 }
 if (!realm) {
-  realm = 'CX-Central'
+  realm = getRealm()
 }
 localStorage.setItem('company', realm)
 
@@ -37,16 +37,14 @@ if (!clientId) {
   clientId = localStorage.getItem('clientId')
 }
 if (!clientId || clientId === 'null') {
-  clientId = 'Cl1-CX-Registration'
+  clientId = getClientIdRegistration()
 }
 localStorage.setItem('clientId', clientId)
 
-const CX_CLIENT = 'Cl1-CX-Registration'
-
 const _kc = new Keycloak({
   url: getCentralIdp(),
-  realm: realm,
-  clientId: clientId,
+  realm,
+  clientId,
   'ssl-required': 'external',
   'public-client': true,
 })
@@ -101,7 +99,7 @@ const getInitials = () =>
 
 const getDomain = () => realm
 
-const getRoles = () => _kc.tokenParsed?.resource_access[CX_CLIENT]?.roles
+const getRoles = () => _kc.tokenParsed?.resource_access[getClientIdRegistration()]?.roles
 
 const hasRole = (roles) => roles.some((role) => _kc.hasRealmRole(role))
 


### PR DESCRIPTION
## Description

Move hard hard coded values to env config.

## Why

Some values like Realm name and ClientIDs were still hard coded and are now configurable.

Related:
- https://github.com/eclipse-tractusx/portal/pull/217

## Issue

[#502](https://github.com/eclipse-tractusx/portal-frontend/issues/502)

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally