### PR TITLE
fix(env): use old values as default until they are provided as env

### DIFF
--- a/src/services/EnvironmentService.ts
+++ b/src/services/EnvironmentService.ts
@@ -18,21 +18,24 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-declare const ENV: any
+declare const ENV: Record<string,string>
 
-export const getApiBase = () =>
-  typeof ENV === 'undefined' ? '' : ENV.PORTAL_BACKEND_URL
+export const getApiBase = () => ENV.PORTAL_BACKEND_URL ?? ''
 
-export const getAssetBase = () =>
-  typeof ENV === 'undefined' ? '' : ENV.PORTAL_ASSETS_URL
+export const getAssetBase = () => ENV.PORTAL_ASSETS_URL ?? ''
 
-export const getCentralIdp = () =>
-  typeof ENV === 'undefined' ? '' : ENV.CENTRALIDP_URL
+export const getCentralIdp = () => ENV.CENTRALIDP_URL ?? ''
+
+export const getRealm = () => ENV.REALM ?? 'CX-Central'
+
+export const getClientIdRegistration = () => ENV.CLIENT_ID_REGISTRATION ?? 'Cl1-CX-Registration'
 
 const EnvironmentService = {
+  getRealm,
+  getClientIdRegistration,
+  getCentralIdp,
   getApiBase,
   getAssetBase,
-  getCentralIdp,
 }
 
 export default EnvironmentService


### PR DESCRIPTION
## Description

Use working defaults for realm and client id

## Why

The values are expected to be injected as env variables however the environment isn't ready yet. Until then we use working defaults so the application is working on dev.

## Issue

n/a

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
