### PR TITLE
fix(deps): upgraded vulnerable dependency

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -96,7 +96,7 @@ npm/npmjs/-/camelcase/5.3.1, MIT, approved, clearlydefined
 npm/npmjs/-/camelcase/6.3.0, MIT, approved, clearlydefined
 npm/npmjs/-/camelize/1.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/caniuse-api/3.0.0, MIT, approved, clearlydefined
-npm/npmjs/-/caniuse-lite/1.0.30001546, CC-BY-4.0, approved, #1196
+npm/npmjs/-/caniuse-lite/1.0.30001610, CC-BY-4.0, approved, #1196
 npm/npmjs/-/case-sensitive-paths-webpack-plugin/2.4.0, MIT, approved, clearlydefined
 npm/npmjs/-/chalk/2.4.2, MIT, approved, clearlydefined
 npm/npmjs/-/chalk/3.0.0, MIT, approved, clearlydefined
@@ -982,7 +982,7 @@ npm/npmjs/-/web-vitals/2.1.4, Apache-2.0, approved, clearlydefined
 npm/npmjs/-/webidl-conversions/4.0.2, BSD-2-Clause, approved, clearlydefined
 npm/npmjs/-/webidl-conversions/5.0.0, BSD-2-Clause, approved, clearlydefined
 npm/npmjs/-/webidl-conversions/6.1.0, BSD-2-Clause, approved, clearlydefined
-npm/npmjs/-/webpack-dev-middleware/5.3.3, MIT, approved, clearlydefined
+npm/npmjs/-/webpack-dev-middleware/5.3.4, MIT, approved, clearlydefined
 npm/npmjs/-/webpack-dev-server/4.15.1, MIT, approved, #8400
 npm/npmjs/-/webpack-manifest-plugin/4.1.1, MIT, approved, clearlydefined
 npm/npmjs/-/webpack-sources/1.4.3, MIT, approved, clearlydefined

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "**/nth-check": "^2.0.1",
     "**/tough-cookie": "^4.1.3",
     "**/webpack": "^5.76.0",
+    "**/webpack-dev-middleware": "^5.3.4",
     "**/@babel/traverse": "^7.23.2",
     "**/css-what": "^6.1.0",
     "**/follow-redirects": "^1.15.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3588,9 +3588,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001538, caniuse-lite@^1.0.30001541:
-  version "1.0.30001546"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001546.tgz#10fdad03436cfe3cc632d3af7a99a0fb497407f0"
-  integrity sha512-zvtSJwuQFpewSyRrI3AsftF6rM0X80mZkChIt1spBGEvRglCrjTniXvinc8JKRoqTwXAgvqTImaN9igfSMtUBw==
+  version "1.0.30001610"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001610.tgz"
+  integrity sha512-QFutAY4NgaelojVMjY63o6XlZyORPaLfyMnsl3HgnWdJUcX6K0oaJymHjH8PT5Gk7sTm8rvC/c5COUQKXqmOMA==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"
@@ -10265,10 +10265,10 @@ webidl-conversions@^6.1.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
   integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
 
-webpack-dev-middleware@^5.3.1:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz#efae67c2793908e7311f1d9b06f2a08dcc97e51f"
-  integrity sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==
+webpack-dev-middleware@^5.3.1, webpack-dev-middleware@^5.3.4:
+  version "5.3.4"
+  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz#eb7b39281cbce10e104eb2b8bf2b63fce49a3517"
+  integrity sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==
   dependencies:
     colorette "^2.0.10"
     memfs "^3.4.3"


### PR DESCRIPTION
## Description

Manually upgraded vulnerable dependency package.

## Why

A high vulnerability has been found in webpack-dev-middleware. Upgraded the package to safe version.

## Issue

Dependabot Alert [#25](https://github.com/eclipse-tractusx/portal-frontend-registration/security/dependabot/25)

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally