### PR TITLE
fix(build): fix output folder structure

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -17,10 +17,10 @@ npm/npmjs/-/argparse/2.0.1, Python-2.0, approved, CQ22954
 npm/npmjs/-/aria-query/5.1.3, Apache-2.0, approved, clearlydefined
 npm/npmjs/-/aria-query/5.3.0, Apache-2.0, approved, clearlydefined
 npm/npmjs/-/array-buffer-byte-length/1.0.1, MIT, approved, #7548
-npm/npmjs/-/array-includes/3.1.7, MIT, approved, #4577
+npm/npmjs/-/array-includes/3.1.8, MIT, approved, #4577
 npm/npmjs/-/array-union/2.1.0, MIT, approved, clearlydefined
-npm/npmjs/-/array.prototype.findlast/1.2.4, MIT, approved, clearlydefined
-npm/npmjs/-/array.prototype.findlastindex/1.2.4, MIT, approved, #9900
+npm/npmjs/-/array.prototype.findlast/1.2.5, MIT, approved, clearlydefined
+npm/npmjs/-/array.prototype.findlastindex/1.2.5, MIT, approved, #9900
 npm/npmjs/-/array.prototype.flat/1.3.2, MIT, approved, #4574
 npm/npmjs/-/array.prototype.flatmap/1.3.2, MIT, approved, #4651
 npm/npmjs/-/array.prototype.toreversed/1.1.2, MIT, approved, clearlydefined
@@ -28,7 +28,6 @@ npm/npmjs/-/array.prototype.tosorted/1.1.3, MIT, approved, #5051
 npm/npmjs/-/arraybuffer.prototype.slice/1.0.3, MIT, approved, #9657
 npm/npmjs/-/asynckit/0.4.0, MIT, approved, clearlydefined
 npm/npmjs/-/attr-accept/2.2.2, MIT, approved, clearlydefined
-npm/npmjs/-/autosuggest-highlight/3.3.4, MIT, approved, clearlydefined
 npm/npmjs/-/available-typed-arrays/1.0.7, MIT, approved, clearlydefined
 npm/npmjs/-/axios/1.6.8, MIT, approved, #11338
 npm/npmjs/-/babel-jest/29.7.0, MIT, approved, clearlydefined
@@ -40,6 +39,7 @@ npm/npmjs/-/babel-preset-jest/29.6.3, MIT, approved, clearlydefined
 npm/npmjs/-/balanced-match/1.0.2, MIT, approved, clearlydefined
 npm/npmjs/-/base64-js/1.5.1, MIT, approved, clearlydefined
 npm/npmjs/-/binary-extensions/2.3.0, MIT, approved, #13867
+npm/npmjs/-/bootstrap/5.3.3, MIT AND CC-BY-3.0, approved, #9867
 npm/npmjs/-/brace-expansion/1.1.11, MIT, approved, clearlydefined
 npm/npmjs/-/brace-expansion/2.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/braces/3.0.2, MIT, approved, clearlydefined
@@ -49,12 +49,12 @@ npm/npmjs/-/bser/2.1.1, Apache-2.0, approved, clearlydefined
 npm/npmjs/-/buffer-from/1.1.2, MIT, approved, clearlydefined
 npm/npmjs/-/buffer/6.0.3, MIT, approved, clearlydefined
 npm/npmjs/-/builtin-modules/3.3.0, MIT, approved, clearlydefined
-npm/npmjs/-/builtins/5.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/builtins/5.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/call-bind/1.0.7, MIT, approved, #11092
 npm/npmjs/-/callsites/3.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/camelcase/5.3.1, MIT, approved, clearlydefined
 npm/npmjs/-/camelcase/6.3.0, MIT, approved, clearlydefined
-npm/npmjs/-/caniuse-lite/1.0.30001599, CC-BY-4.0, approved, #1196
+npm/npmjs/-/caniuse-lite/1.0.30001610, CC-BY-4.0, approved, #1196
 npm/npmjs/-/chalk/2.4.2, MIT, approved, clearlydefined
 npm/npmjs/-/chalk/3.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/chalk/4.1.2, MIT, approved, clearlydefined
@@ -94,7 +94,7 @@ npm/npmjs/-/dayjs/1.11.10, MIT, approved, #9149
 npm/npmjs/-/debug/3.2.7, MIT, approved, clearlydefined
 npm/npmjs/-/debug/4.3.4, MIT, approved, clearlydefined
 npm/npmjs/-/decimal.js/10.4.3, MIT, approved, clearlydefined
-npm/npmjs/-/dedent/1.5.1, MIT, approved, clearlydefined
+npm/npmjs/-/dedent/1.5.3, MIT, approved, #14381
 npm/npmjs/-/deep-equal/2.2.3, MIT, approved, #8406
 npm/npmjs/-/deep-is/0.1.4, MIT, approved, #2130
 npm/npmjs/-/deepmerge/4.3.1, MIT, approved, #7032
@@ -113,14 +113,12 @@ npm/npmjs/-/dom-accessibility-api/0.6.3, MIT, approved, clearlydefined
 npm/npmjs/-/dom-helpers/5.2.1, MIT, approved, clearlydefined
 npm/npmjs/-/domexception/4.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/dot-case/3.0.4, MIT, approved, clearlydefined
-npm/npmjs/-/electron-to-chromium/1.4.710, ISC, approved, #1950
+npm/npmjs/-/electron-to-chromium/1.4.737, ISC, approved, #1950
 npm/npmjs/-/emittery/0.13.1, MIT, approved, clearlydefined
 npm/npmjs/-/emoji-regex/8.0.0, MIT, approved, clearlydefined
-npm/npmjs/-/enquire.js/2.1.6, MIT, approved, clearlydefined
 npm/npmjs/-/entities/4.5.0, BSD-2-Clause, approved, #7910
 npm/npmjs/-/error-ex/1.3.2, MIT, approved, clearlydefined
-npm/npmjs/-/es-abstract/1.22.5, MIT, approved, #9656
-npm/npmjs/-/es-abstract/1.23.2, MIT, approved, clearlydefined
+npm/npmjs/-/es-abstract/1.23.3, MIT, approved, clearlydefined
 npm/npmjs/-/es-define-property/1.0.0, MIT, approved, #13222
 npm/npmjs/-/es-errors/1.3.0, MIT, approved, #13162
 npm/npmjs/-/es-get-iterator/1.1.3, MIT, approved, clearlydefined
@@ -129,19 +127,19 @@ npm/npmjs/-/es-object-atoms/1.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/es-set-tostringtag/2.0.3, MIT, approved, #6218
 npm/npmjs/-/es-shim-unscopables/1.0.2, MIT, approved, clearlydefined
 npm/npmjs/-/es-to-primitive/1.2.1, MIT, approved, clearlydefined
-npm/npmjs/-/esbuild/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12979
+npm/npmjs/-/esbuild/0.20.2, MIT, approved, clearlydefined
 npm/npmjs/-/escalade/3.1.2, MIT, approved, clearlydefined
 npm/npmjs/-/escape-string-regexp/1.0.5, MIT, approved, clearlydefined
 npm/npmjs/-/escape-string-regexp/2.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/escape-string-regexp/4.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/escodegen/2.1.0, BSD-2-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #9306
-npm/npmjs/-/eslint-compat-utils/0.1.2, MIT, approved, clearlydefined
+npm/npmjs/-/eslint-compat-utils/0.5.0, MIT, approved, #13999
 npm/npmjs/-/eslint-config-love/43.1.0, MIT, approved, #13906
 npm/npmjs/-/eslint-config-prettier/9.1.0, MIT, approved, #11979
 npm/npmjs/-/eslint-config-standard/17.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/eslint-import-resolver-node/0.3.9, MIT, approved, #9923
 npm/npmjs/-/eslint-module-utils/2.8.1, MIT, approved, #8209
-npm/npmjs/-/eslint-plugin-es-x/7.5.0, MIT, approved, #11867
+npm/npmjs/-/eslint-plugin-es-x/7.6.0, MIT, approved, #14003
 npm/npmjs/-/eslint-plugin-import/2.29.1, MIT, approved, #11187
 npm/npmjs/-/eslint-plugin-n/16.6.2, MIT, approved, #12657
 npm/npmjs/-/eslint-plugin-promise/6.1.1, ISC, approved, clearlydefined
@@ -182,6 +180,7 @@ npm/npmjs/-/fsevents/2.3.3, MIT, approved, #2967
 npm/npmjs/-/function-bind/1.1.2, MIT, approved, #11063
 npm/npmjs/-/function.prototype.name/1.1.6, MIT, approved, #10255
 npm/npmjs/-/functions-have-names/1.2.3, MIT, approved, clearlydefined
+npm/npmjs/-/fuse.js/3.6.1, Apache-2.0, approved, clearlydefined
 npm/npmjs/-/gensync/1.0.0-beta.2, MIT, approved, clearlydefined
 npm/npmjs/-/get-caller-file/2.0.5, ISC, approved, clearlydefined
 npm/npmjs/-/get-intrinsic/1.2.4, MIT, approved, #8453
@@ -209,6 +208,8 @@ npm/npmjs/-/has-proto/1.0.3, MIT, approved, #6175
 npm/npmjs/-/has-symbols/1.0.3, MIT, approved, clearlydefined
 npm/npmjs/-/has-tostringtag/1.0.2, MIT, approved, #13161
 npm/npmjs/-/hasown/2.0.2, MIT, approved, #11097
+npm/npmjs/-/history/4.10.1, MIT, approved, clearlydefined
+npm/npmjs/-/history/5.3.0, MIT, approved, clearlydefined
 npm/npmjs/-/hoist-non-react-statics/3.3.2, BSD-3-Clause, approved, clearlydefined
 npm/npmjs/-/html-encoding-sniffer/3.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/html-escaper/2.0.2, MIT, approved, clearlydefined
@@ -217,8 +218,8 @@ npm/npmjs/-/http-proxy-agent/5.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/https-proxy-agent/5.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/human-signals/2.1.0, Apache-2.0, approved, clearlydefined
 npm/npmjs/-/husky/9.0.11, MIT, approved, clearlydefined
-npm/npmjs/-/i18next-browser-languagedetector/7.2.0, MIT, approved, clearlydefined
-npm/npmjs/-/i18next/23.10.1, MIT, approved, #13869
+npm/npmjs/-/i18next-browser-languagedetector/7.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/i18next/23.11.2, MIT, approved, #14383
 npm/npmjs/-/iconv-lite/0.6.3, MIT, approved, clearlydefined
 npm/npmjs/-/identity-obj-proxy/3.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/ieee754/1.2.1, BSD-3-Clause, approved, clearlydefined
@@ -232,6 +233,7 @@ npm/npmjs/-/indent-string/4.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/inflight/1.0.6, ISC, approved, clearlydefined
 npm/npmjs/-/inherits/2.0.4, ISC, approved, clearlydefined
 npm/npmjs/-/internal-slot/1.0.7, MIT, approved, #7118
+npm/npmjs/-/invariant/2.2.4, MIT, approved, #1034
 npm/npmjs/-/is-arguments/1.1.1, MIT, approved, clearlydefined
 npm/npmjs/-/is-array-buffer/3.0.4, MIT, approved, #6248
 npm/npmjs/-/is-arrayish/0.2.1, MIT, approved, clearlydefined
@@ -266,6 +268,7 @@ npm/npmjs/-/is-typed-array/1.1.13, MIT, approved, #4853
 npm/npmjs/-/is-weakmap/2.0.2, MIT, approved, clearlydefined
 npm/npmjs/-/is-weakref/1.0.2, MIT, approved, clearlydefined
 npm/npmjs/-/is-weakset/2.0.3, MIT, approved, clearlydefined
+npm/npmjs/-/isarray/0.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/isarray/2.0.5, MIT, approved, clearlydefined
 npm/npmjs/-/isexe/2.0.0, ISC, approved, clearlydefined
 npm/npmjs/-/istanbul-lib-coverage/3.2.2, BSD-3-Clause, approved, clearlydefined
@@ -302,8 +305,7 @@ npm/npmjs/-/jest-validate/29.7.0, MIT, approved, clearlydefined
 npm/npmjs/-/jest-watcher/29.7.0, MIT, approved, clearlydefined
 npm/npmjs/-/jest-worker/29.7.0, MIT, approved, clearlydefined
 npm/npmjs/-/jest/29.7.0, MIT, approved, clearlydefined
-npm/npmjs/-/jquery/3.7.1, MIT, approved, clearlydefined
-npm/npmjs/-/js-sha256/0.10.1, MIT, approved, clearlydefined
+npm/npmjs/-/js-sha256/0.11.0, MIT, approved, clearlydefined
 npm/npmjs/-/js-tokens/4.0.0, MIT, approved, #2401
 npm/npmjs/-/js-yaml/3.14.1, MIT, approved, clearlydefined
 npm/npmjs/-/js-yaml/4.1.0, MIT, approved, clearlydefined
@@ -313,12 +315,12 @@ npm/npmjs/-/json-buffer/3.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/json-parse-even-better-errors/2.3.1, MIT, approved, clearlydefined
 npm/npmjs/-/json-schema-traverse/0.4.1, MIT, approved, clearlydefined
 npm/npmjs/-/json-stable-stringify-without-jsonify/1.0.1, MIT, approved, clearlydefined
-npm/npmjs/-/json2mq/0.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/json5/1.0.2, MIT, approved, CQ22351
 npm/npmjs/-/json5/2.2.3, MIT, approved, #2126
 npm/npmjs/-/jsx-ast-utils/3.3.5, MIT, approved, #9209
+npm/npmjs/-/just-curry-it/5.3.0, MIT, approved, clearlydefined
 npm/npmjs/-/jwt-decode/4.0.0, MIT, approved, clearlydefined
-npm/npmjs/-/keycloak-js/23.0.7, Apache-2.0 AND MIT AND EPL-1.0 AND LicenseRef-scancode-oasis-ws-security-spec AND W3C AND LicenseRef-scancode-ws-policy-specification AND W3C AND W3C-19980720 AND (AFL-2.1 OR LGPL-2.0-only) AND (Apache-2.0 AND MIT) AND (Apache-2.0 AND MIT), approved, #11737
+npm/npmjs/-/keycloak-js/24.0.2, Apache-2.0, approved, clearlydefined
 npm/npmjs/-/keyv/4.5.4, MIT, approved, #4674
 npm/npmjs/-/kleur/3.0.3, MIT, approved, clearlydefined
 npm/npmjs/-/leven/3.1.0, MIT, approved, clearlydefined
@@ -348,13 +350,15 @@ npm/npmjs/-/mime-db/1.52.0, MIT, approved, clearlydefined
 npm/npmjs/-/mime-types/2.1.35, MIT, approved, clearlydefined
 npm/npmjs/-/mimic-fn/2.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/min-indent/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/mini-create-react-context/0.4.1, MIT, approved, clearlydefined
 npm/npmjs/-/minimatch/3.1.2, ISC, approved, clearlydefined
 npm/npmjs/-/minimatch/9.0.3, ISC, approved, #9190
+npm/npmjs/-/minimatch/9.0.4, ISC, approved, #9190
 npm/npmjs/-/minimist/1.2.8, MIT, approved, #5886
 npm/npmjs/-/ms/2.1.2, MIT, approved, #5895
 npm/npmjs/-/ms/2.1.3, MIT, approved, #5895
 npm/npmjs/-/nanoid/3.3.7, MIT, approved, #7571
-npm/npmjs/-/nanoid/5.0.6, MIT, approved, clearlydefined
+npm/npmjs/-/nanoid/5.0.7, MIT, approved, clearlydefined
 npm/npmjs/-/natural-compare/1.4.0, MIT, approved, clearlydefined
 npm/npmjs/-/no-case/3.0.4, MIT, approved, clearlydefined
 npm/npmjs/-/node-int64/0.4.0, MIT, approved, clearlydefined
@@ -370,7 +374,7 @@ npm/npmjs/-/object.assign/4.1.5, MIT, approved, #3232
 npm/npmjs/-/object.entries/1.1.8, MIT, approved, #4671
 npm/npmjs/-/object.fromentries/2.0.8, MIT, approved, #4600
 npm/npmjs/-/object.groupby/1.0.3, MIT, approved, #10360
-npm/npmjs/-/object.hasown/1.1.3, MIT, approved, #4667
+npm/npmjs/-/object.hasown/1.1.4, MIT, approved, #4667
 npm/npmjs/-/object.values/1.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/once/1.4.0, ISC, approved, clearlydefined
 npm/npmjs/-/onetime/5.1.2, MIT, approved, clearlydefined
@@ -388,6 +392,7 @@ npm/npmjs/-/path-exists/4.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/path-is-absolute/1.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/path-key/3.1.1, MIT, approved, clearlydefined
 npm/npmjs/-/path-parse/1.0.7, MIT, approved, clearlydefined
+npm/npmjs/-/path-to-regexp/1.8.0, MIT, approved, clearlydefined
 npm/npmjs/-/path-type/4.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/phone/3.1.42, MIT, approved, #10500
 npm/npmjs/-/picocolors/1.0.0, ISC, approved, clearlydefined
@@ -395,65 +400,74 @@ npm/npmjs/-/picomatch/2.3.1, MIT, approved, clearlydefined
 npm/npmjs/-/pirates/4.0.6, MIT, approved, #680
 npm/npmjs/-/pkg-dir/4.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/possible-typed-array-names/1.0.0, MIT, approved, clearlydefined
-npm/npmjs/-/postcss/8.4.36, MIT, approved, #3545
+npm/npmjs/-/postcss/8.4.38, MIT, approved, #3545
 npm/npmjs/-/prelude-ls/1.2.1, MIT, approved, clearlydefined
 npm/npmjs/-/prettier/3.2.5, MIT AND ISC AND BSD-2-Clause AND BSD-3-Clause AND Apache-2.0, approved, #13320
 npm/npmjs/-/pretty-format/27.5.1, 0BSD AND Apache-2.0 AND BSD-2-Clause AND MIT, approved, #1948
 npm/npmjs/-/pretty-format/29.7.0, MIT, approved, clearlydefined
 npm/npmjs/-/prompts/2.4.2, MIT, approved, clearlydefined
+npm/npmjs/-/prop-types-extra/1.1.1, , approved, CQ22354
 npm/npmjs/-/prop-types/15.8.1, MIT, approved, clearlydefined
 npm/npmjs/-/proxy-from-env/1.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/psl/1.9.0, MIT AND CC0-1.0, approved, #3080
 npm/npmjs/-/punycode/2.3.1, MIT, approved, #6373
-npm/npmjs/-/pure-rand/6.0.4, MIT AND (BSD-2-Clause AND ISC AND MIT), approved, #8423
-npm/npmjs/-/qs/6.12.0, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/-/pure-rand/6.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/qs/6.12.1, BSD-3-Clause, approved, #14380
 npm/npmjs/-/querystringify/2.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/queue-microtask/1.2.3, MIT, approved, clearlydefined
+npm/npmjs/-/react-bootstrap/2.10.2, MIT AND BSD-3-Clause AND Apache-2.0 AND CC-PDDC, approved, #14382
+npm/npmjs/-/react-datepicker/6.8.0, MIT AND BSD-3-Clause, approved, #14379
 npm/npmjs/-/react-dom/18.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/react-dropzone-uploader/2.11.0, MIT, approved, clearlydefined
 npm/npmjs/-/react-dropzone/14.2.3, MIT, approved, clearlydefined
 npm/npmjs/-/react-fast-compare/3.2.2, MIT, approved, clearlydefined
-npm/npmjs/-/react-hook-form/7.51.1, MIT, approved, #13909
+npm/npmjs/-/react-hook-form/7.51.3, MIT, approved, #13909
 npm/npmjs/-/react-i18next/14.1.0, MIT AND Apache-2.0, approved, #13870
+npm/npmjs/-/react-icons/5.1.0, Apache-2.0 AND CC-BY-3.0 AND CC-BY-4.0 AND CC-BY-SA-3.0 AND CC0-1.0 AND ISC AND MIT AND MPL-2.0 AND OFL-1.1 AND MIT AND (Apache-2.0 AND CC-BY-3.0 AND CC-BY-4.0 AND CC-BY-SA-3.0 AND CC0-1.0 AND MIT AND OFL-1.1), approved, #14386
 npm/npmjs/-/react-is/16.13.1, MIT, approved, clearlydefined
 npm/npmjs/-/react-is/17.0.2, MIT, approved, clearlydefined
 npm/npmjs/-/react-is/18.2.0, MIT, approved, clearlydefined
-npm/npmjs/-/react-player/2.15.1, MIT, approved, #13914
-npm/npmjs/-/react-redux/9.1.0, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-3-Clause, approved, #13913
+npm/npmjs/-/react-lifecycles-compat/3.0.4, MIT, approved, clearlydefined
+npm/npmjs/-/react-onclickoutside/6.13.0, MIT, approved, clearlydefined
+npm/npmjs/-/react-player/2.16.0, MIT, approved, #14388
+npm/npmjs/-/react-redux/9.1.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-3-Clause, approved, #13913
 npm/npmjs/-/react-refresh/0.14.0, MIT, approved, clearlydefined
-npm/npmjs/-/react-router-dom/6.22.3, MIT, approved, #13333
-npm/npmjs/-/react-router/6.22.3, MIT, approved, clearlydefined
-npm/npmjs/-/react-slick/0.30.2, MIT, approved, #14009
+npm/npmjs/-/react-router-dom/5.3.3, MIT AND BSD-3-Clause, approved, #3023
+npm/npmjs/-/react-router/5.3.3, MIT AND BSD-3-Clause AND CC-BY-4.0, approved, #3024
+npm/npmjs/-/react-search-input/0.11.3, MIT, approved, clearlydefined
+npm/npmjs/-/react-toastify/10.0.5, MIT, approved, #13093
+npm/npmjs/-/react-tooltip/5.26.3, MIT, approved, clearlydefined
 npm/npmjs/-/react-transition-group/4.4.5, BSD-3-Clause, approved, CQ22955
 npm/npmjs/-/react/18.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/readdirp/3.6.0, MIT, approved, #2977
 npm/npmjs/-/redent/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/reduce-reducers/1.0.4, MIT, approved, clearlydefined
+npm/npmjs/-/redux-actions/3.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/redux-thunk/3.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/redux/4.2.1, CC0-1.0 AND MIT, approved, #7046
 npm/npmjs/-/redux/5.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/reflect.getprototypeof/1.0.6, MIT, approved, #13910
 npm/npmjs/-/regenerator-runtime/0.14.1, MIT, approved, #9897
 npm/npmjs/-/regexp.prototype.flags/1.5.2, MIT, approved, #8199
-npm/npmjs/-/remove-accents/0.4.4, MIT, approved, clearlydefined
 npm/npmjs/-/require-directory/2.1.1, MIT, approved, clearlydefined
 npm/npmjs/-/requires-port/1.0.0, MIT, approved, clearlydefined
-npm/npmjs/-/reselect/4.1.8, MIT, approved, clearlydefined
 npm/npmjs/-/reselect/5.1.0, MIT, approved, clearlydefined
-npm/npmjs/-/resize-observer-polyfill/1.5.1, MIT, approved, clearlydefined
 npm/npmjs/-/resolve-cwd/3.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/resolve-from/4.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/resolve-from/5.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/resolve-pathname/3.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/resolve-pkg-maps/1.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/resolve.exports/2.0.2, MIT, approved, clearlydefined
 npm/npmjs/-/resolve/1.22.8, MIT AND ISC, approved, #2409
 npm/npmjs/-/resolve/2.0.0-next.5, MIT AND ISC, approved, #3078
 npm/npmjs/-/reusify/1.0.4, MIT, approved, clearlydefined
 npm/npmjs/-/rimraf/3.0.2, ISC, approved, clearlydefined
-npm/npmjs/-/rollup/4.13.0, MIT, approved, clearlydefined
+npm/npmjs/-/rollup/4.14.3, MIT, approved, clearlydefined
 npm/npmjs/-/run-parallel/1.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/safe-array-concat/1.1.2, MIT, approved, clearlydefined
 npm/npmjs/-/safe-regex-test/1.0.3, MIT, approved, clearlydefined
 npm/npmjs/-/safer-buffer/2.1.2, MIT, approved, clearlydefined
-npm/npmjs/-/sass/1.72.0, MIT, approved, clearlydefined
+npm/npmjs/-/sass/1.75.0, MIT, approved, clearlydefined
 npm/npmjs/-/saxes/6.0.0, ISC, approved, clearlydefined
 npm/npmjs/-/scheduler/0.23.0, MIT, approved, clearlydefined
 npm/npmjs/-/semver/6.3.1, ISC, approved, clearlydefined
@@ -466,7 +480,6 @@ npm/npmjs/-/side-channel/1.0.6, MIT, approved, clearlydefined
 npm/npmjs/-/signal-exit/3.0.7, ISC, approved, #5892
 npm/npmjs/-/sisteransi/1.0.5, MIT, approved, clearlydefined
 npm/npmjs/-/slash/3.0.0, MIT, approved, clearlydefined
-npm/npmjs/-/slick-carousel/1.8.1, MIT, approved, #2986
 npm/npmjs/-/snake-case/3.0.4, MIT, approved, clearlydefined
 npm/npmjs/-/source-map-js/1.2.0, BSD-3-Clause, approved, #13911
 npm/npmjs/-/source-map-support/0.5.13, MIT, approved, clearlydefined
@@ -475,13 +488,12 @@ npm/npmjs/-/source-map/0.6.1, BSD-3-Clause, approved, #2417
 npm/npmjs/-/sprintf-js/1.0.3, BSD-3-Clause, approved, #949
 npm/npmjs/-/stack-utils/2.0.6, MIT, approved, clearlydefined
 npm/npmjs/-/stop-iteration-iterator/1.0.0, MIT, approved, clearlydefined
-npm/npmjs/-/string-convert/0.2.1, MIT, approved, clearlydefined
 npm/npmjs/-/string-length/4.0.2, MIT, approved, clearlydefined
 npm/npmjs/-/string-width/4.2.3, MIT, approved, clearlydefined
-npm/npmjs/-/string.prototype.matchall/4.0.10, MIT, approved, #4571
+npm/npmjs/-/string.prototype.matchall/4.0.11, MIT, approved, #4571
 npm/npmjs/-/string.prototype.trim/1.2.9, MIT, approved, #10361
 npm/npmjs/-/string.prototype.trimend/1.0.8, MIT, approved, #4564
-npm/npmjs/-/string.prototype.trimstart/1.0.7, MIT, approved, #4647
+npm/npmjs/-/string.prototype.trimstart/1.0.8, MIT, approved, #4647
 npm/npmjs/-/strip-ansi/6.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/strip-bom/3.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/strip-bom/4.0.0, MIT, approved, clearlydefined
@@ -495,8 +507,11 @@ npm/npmjs/-/supports-color/8.1.1, MIT, approved, clearlydefined
 npm/npmjs/-/supports-preserve-symlinks-flag/1.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/svg-parser/2.0.4, MIT, approved, clearlydefined
 npm/npmjs/-/symbol-tree/3.2.4, MIT, approved, clearlydefined
+npm/npmjs/-/tabbable/6.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/test-exclude/6.0.0, ISC, approved, clearlydefined
 npm/npmjs/-/text-table/0.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/tiny-invariant/1.3.3, MIT, approved, clearlydefined
+npm/npmjs/-/tiny-warning/1.0.3, MIT, approved, clearlydefined
 npm/npmjs/-/tmpl/1.0.5, BSD-3-Clause, approved, clearlydefined
 npm/npmjs/-/to-fast-properties/2.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/to-regex-range/5.0.1, MIT, approved, clearlydefined
@@ -515,23 +530,28 @@ npm/npmjs/-/type-fest/0.21.3, MIT OR (CC0-1.0 AND MIT), approved, clearlydefined
 npm/npmjs/-/typed-array-buffer/1.0.2, MIT, approved, #9658
 npm/npmjs/-/typed-array-byte-length/1.0.1, MIT, approved, #9659
 npm/npmjs/-/typed-array-byte-offset/1.0.2, MIT, approved, #9407
-npm/npmjs/-/typed-array-length/1.0.5, MIT, approved, #6246
-npm/npmjs/-/typescript/5.4.3, Apache-2.0 AND MIT AND CC-BY-4.0 AND Unicode-DFS-2016 AND W3C-20150513, approved, #13647
+npm/npmjs/-/typed-array-length/1.0.6, MIT, approved, #6246
+npm/npmjs/-/typescript/5.4.5, Apache-2.0 AND MIT AND CC-BY-4.0 AND Unicode-DFS-2016 AND W3C-20150513, approved, #13647
 npm/npmjs/-/unbox-primitive/1.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/uncontrollable/7.2.1, MIT AND BSD-3-Clause, approved, #3025
+npm/npmjs/-/uncontrollable/8.0.4, MIT, approved, clearlydefined
 npm/npmjs/-/undici-types/5.26.5, MIT, approved, clearlydefined
 npm/npmjs/-/universalify/0.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/update-browserslist-db/1.0.13, MIT, approved, #8237
 npm/npmjs/-/uri-js/4.4.1, BSD-2-Clause, approved, #1086
 npm/npmjs/-/url-parse/1.5.10, MIT, approved, clearlydefined
 npm/npmjs/-/use-sync-external-store/1.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/uuid/9.0.1, MIT AND (BSD-3-Clause AND MIT), approved, #6869
 npm/npmjs/-/v8-compile-cache-lib/3.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/v8-to-istanbul/9.2.0, ISC, approved, clearlydefined
+npm/npmjs/-/value-equal/1.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/vite-plugin-svgr/4.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/vite-tsconfig-paths/4.3.2, MIT, approved, clearlydefined
-npm/npmjs/-/vite/5.1.6, MIT AND (ISC AND MIT) AND (Apache-2.0 AND BSD-2-Clause AND CC0-1.0 AND ISC AND MIT) AND (BSD-3-Clause AND MIT) AND ISC AND (BSD-2-Clause AND BSD-3-Clause), approved, #13202
+npm/npmjs/-/vite/5.2.9, MIT AND (ISC AND MIT) AND (Apache-2.0 AND BSD-2-Clause AND CC0-1.0 AND ISC AND MIT) AND (BSD-3-Clause AND MIT) AND ISC AND (BSD-2-Clause AND BSD-3-Clause), approved, #13953
 npm/npmjs/-/void-elements/3.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/w3c-xmlserializer/4.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/walker/1.0.8, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/warning/4.0.3, MIT, approved, CQ22359
 npm/npmjs/-/webidl-conversions/7.0.0, BSD-2-Clause, approved, clearlydefined
 npm/npmjs/-/whatwg-encoding/2.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/whatwg-mimetype/3.0.0, MIT, approved, clearlydefined
@@ -558,15 +578,15 @@ npm/npmjs/-/yocto-queue/0.1.0, MIT, approved, clearlydefined
 npm/npmjs/@aashutoshrathi/word-wrap/1.2.6, MIT, approved, #9212
 npm/npmjs/@adobe/css-tools/4.3.3, MIT, approved, #9985
 npm/npmjs/@ampproject/remapping/2.3.0, Apache-2.0, approved, clearlydefined
-npm/npmjs/@babel/code-frame/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13943
-npm/npmjs/@babel/compat-data/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13915
-npm/npmjs/@babel/core/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13942
-npm/npmjs/@babel/generator/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13919
+npm/npmjs/@babel/code-frame/7.24.2, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13943
+npm/npmjs/@babel/compat-data/7.24.4, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13915
+npm/npmjs/@babel/core/7.24.4, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13942
+npm/npmjs/@babel/generator/7.24.4, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13919
 npm/npmjs/@babel/helper-compilation-targets/7.23.6, MIT, approved, clearlydefined
 npm/npmjs/@babel/helper-environment-visitor/7.22.20, MIT, approved, #8934
 npm/npmjs/@babel/helper-function-name/7.23.0, MIT, approved, clearlydefined
 npm/npmjs/@babel/helper-hoist-variables/7.22.5, MIT, approved, #8957
-npm/npmjs/@babel/helper-module-imports/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13944
+npm/npmjs/@babel/helper-module-imports/7.24.3, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13944
 npm/npmjs/@babel/helper-module-transforms/7.23.3, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #11537
 npm/npmjs/@babel/helper-plugin-utils/7.24.0, MIT, approved, clearlydefined
 npm/npmjs/@babel/helper-simple-access/7.22.5, MIT, approved, #9048
@@ -574,9 +594,9 @@ npm/npmjs/@babel/helper-split-export-declaration/7.22.6, MIT, approved, #8938
 npm/npmjs/@babel/helper-string-parser/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13923
 npm/npmjs/@babel/helper-validator-identifier/7.22.20, MIT, approved, #8955
 npm/npmjs/@babel/helper-validator-option/7.23.5, MIT, approved, clearlydefined
-npm/npmjs/@babel/helpers/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13922
-npm/npmjs/@babel/highlight/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13941
-npm/npmjs/@babel/parser/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13492
+npm/npmjs/@babel/helpers/7.24.4, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13922
+npm/npmjs/@babel/highlight/7.24.2, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13941
+npm/npmjs/@babel/parser/7.24.4, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13492
 npm/npmjs/@babel/plugin-syntax-async-generators/7.8.4, MIT, approved, #1973
 npm/npmjs/@babel/plugin-syntax-bigint/7.8.3, MIT, approved, clearlydefined
 npm/npmjs/@babel/plugin-syntax-class-properties/7.12.13, MIT, approved, clearlydefined
@@ -593,52 +613,48 @@ npm/npmjs/@babel/plugin-syntax-top-level-await/7.14.5, MIT, approved, clearlydef
 npm/npmjs/@babel/plugin-syntax-typescript/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13924
 npm/npmjs/@babel/plugin-transform-react-jsx-self/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13928
 npm/npmjs/@babel/plugin-transform-react-jsx-source/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13925
-npm/npmjs/@babel/runtime/7.23.6, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #10718
-npm/npmjs/@babel/runtime/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13900
+npm/npmjs/@babel/runtime/7.24.4, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13900
 npm/npmjs/@babel/template/7.24.0, MIT, approved, clearlydefined
 npm/npmjs/@babel/traverse/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13926
 npm/npmjs/@babel/types/7.24.0, MIT, approved, clearlydefined
 npm/npmjs/@bcoe/v8-coverage/0.2.3, ISC AND MIT, approved, clearlydefined
-npm/npmjs/@catena-x/portal-shared-components/3.0.4, Apache-2.0 AND CC-BY-4.0 AND OFL-1.1, approved, #14247
 npm/npmjs/@cspotcode/source-map-support/0.8.1, MIT, approved, clearlydefined
-npm/npmjs/@date-io/core/3.0.0, MIT, approved, clearlydefined
-npm/npmjs/@date-io/date-fns/3.0.0, MIT, approved, #14023
 npm/npmjs/@emotion/babel-plugin/11.11.0, MIT, approved, #8386
 npm/npmjs/@emotion/cache/11.11.0, MIT, approved, #8401
 npm/npmjs/@emotion/hash/0.9.1, MIT, approved, #8394
 npm/npmjs/@emotion/is-prop-valid/1.2.2, MIT, approved, #8392
 npm/npmjs/@emotion/memoize/0.8.1, MIT, approved, #8408
 npm/npmjs/@emotion/react/11.11.4, MIT AND (BSD-3-Clause AND MIT), approved, #8931
-npm/npmjs/@emotion/serialize/1.1.3, MIT, approved, #8417
+npm/npmjs/@emotion/serialize/1.1.4, MIT, approved, #8417
 npm/npmjs/@emotion/sheet/1.2.2, MIT, approved, #8389
-npm/npmjs/@emotion/styled/11.11.0, MIT, approved, clearlydefined
+npm/npmjs/@emotion/styled/11.11.5, MIT, approved, clearlydefined
 npm/npmjs/@emotion/unitless/0.8.1, MIT, approved, #8403
 npm/npmjs/@emotion/use-insertion-effect-with-fallbacks/1.0.1, MIT, approved, #8419
 npm/npmjs/@emotion/utils/1.2.1, MIT, approved, #8415
 npm/npmjs/@emotion/weak-memoize/0.3.1, MIT, approved, #8402
-npm/npmjs/@esbuild/aix-ppc64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12976
-npm/npmjs/@esbuild/android-arm/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #11629
-npm/npmjs/@esbuild/android-arm64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12967
-npm/npmjs/@esbuild/android-x64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #11638
-npm/npmjs/@esbuild/darwin-arm64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12987
-npm/npmjs/@esbuild/darwin-x64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12974
-npm/npmjs/@esbuild/freebsd-arm64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12973
-npm/npmjs/@esbuild/freebsd-x64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12988
-npm/npmjs/@esbuild/linux-arm/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12968
-npm/npmjs/@esbuild/linux-arm64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12985
-npm/npmjs/@esbuild/linux-ia32/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12972
-npm/npmjs/@esbuild/linux-loong64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12971
-npm/npmjs/@esbuild/linux-mips64el/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12977
-npm/npmjs/@esbuild/linux-ppc64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12966
-npm/npmjs/@esbuild/linux-riscv64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12986
-npm/npmjs/@esbuild/linux-s390x/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12975
-npm/npmjs/@esbuild/linux-x64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12980
-npm/npmjs/@esbuild/netbsd-x64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12959
-npm/npmjs/@esbuild/openbsd-x64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12981
-npm/npmjs/@esbuild/sunos-x64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12970
-npm/npmjs/@esbuild/win32-arm64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12960
-npm/npmjs/@esbuild/win32-ia32/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12969
-npm/npmjs/@esbuild/win32-x64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12961
+npm/npmjs/@esbuild/aix-ppc64/0.20.2, MIT, approved, clearlydefined
+npm/npmjs/@esbuild/android-arm/0.20.2, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #13952
+npm/npmjs/@esbuild/android-arm64/0.20.2, MIT, approved, clearlydefined
+npm/npmjs/@esbuild/android-x64/0.20.2, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #13954
+npm/npmjs/@esbuild/darwin-arm64/0.20.2, MIT, approved, clearlydefined
+npm/npmjs/@esbuild/darwin-x64/0.20.2, MIT, approved, clearlydefined
+npm/npmjs/@esbuild/freebsd-arm64/0.20.2, MIT, approved, clearlydefined
+npm/npmjs/@esbuild/freebsd-x64/0.20.2, MIT, approved, clearlydefined
+npm/npmjs/@esbuild/linux-arm/0.20.2, MIT, approved, clearlydefined
+npm/npmjs/@esbuild/linux-arm64/0.20.2, MIT, approved, clearlydefined
+npm/npmjs/@esbuild/linux-ia32/0.20.2, MIT, approved, clearlydefined
+npm/npmjs/@esbuild/linux-loong64/0.20.2, MIT, approved, clearlydefined
+npm/npmjs/@esbuild/linux-mips64el/0.20.2, MIT, approved, clearlydefined
+npm/npmjs/@esbuild/linux-ppc64/0.20.2, MIT, approved, clearlydefined
+npm/npmjs/@esbuild/linux-riscv64/0.20.2, MIT, approved, clearlydefined
+npm/npmjs/@esbuild/linux-s390x/0.20.2, MIT, approved, clearlydefined
+npm/npmjs/@esbuild/linux-x64/0.20.2, MIT, approved, clearlydefined
+npm/npmjs/@esbuild/netbsd-x64/0.20.2, MIT, approved, clearlydefined
+npm/npmjs/@esbuild/openbsd-x64/0.20.2, MIT, approved, clearlydefined
+npm/npmjs/@esbuild/sunos-x64/0.20.2, MIT, approved, clearlydefined
+npm/npmjs/@esbuild/win32-arm64/0.20.2, MIT, approved, clearlydefined
+npm/npmjs/@esbuild/win32-ia32/0.20.2, MIT, approved, clearlydefined
+npm/npmjs/@esbuild/win32-x64/0.20.2, MIT, approved, clearlydefined
 npm/npmjs/@eslint-community/eslint-utils/4.4.0, MIT, approved, #8032
 npm/npmjs/@eslint-community/regexpp/4.10.0, MIT, approved, clearlydefined
 npm/npmjs/@eslint/eslintrc/2.1.4, MIT, approved, #9908
@@ -646,11 +662,12 @@ npm/npmjs/@eslint/js/8.57.0, MIT, approved, clearlydefined
 npm/npmjs/@floating-ui/core/1.6.0, MIT, approved, clearlydefined
 npm/npmjs/@floating-ui/dom/1.6.3, MIT, approved, clearlydefined
 npm/npmjs/@floating-ui/react-dom/2.0.8, MIT, approved, clearlydefined
+npm/npmjs/@floating-ui/react/0.26.12, MIT AND ISC AND (CC-BY-4.0 AND MIT), approved, #14384
 npm/npmjs/@floating-ui/utils/0.2.1, MIT, approved, clearlydefined
 npm/npmjs/@hookform/error-message/2.0.1, MIT, approved, clearlydefined
 npm/npmjs/@humanwhocodes/config-array/0.11.14, Apache-2.0, approved, #5876
 npm/npmjs/@humanwhocodes/module-importer/1.0.1, Apache-2.0, approved, clearlydefined
-npm/npmjs/@humanwhocodes/object-schema/2.0.2, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/@humanwhocodes/object-schema/2.0.3, BSD-3-Clause, approved, clearlydefined
 npm/npmjs/@istanbuljs/load-nyc-config/1.1.0, ISC, approved, clearlydefined
 npm/npmjs/@istanbuljs/schema/0.1.3, MIT, approved, clearlydefined
 npm/npmjs/@jest/console/29.7.0, MIT, approved, clearlydefined
@@ -674,42 +691,41 @@ npm/npmjs/@jridgewell/sourcemap-codec/1.4.15, MIT, approved, clearlydefined
 npm/npmjs/@jridgewell/trace-mapping/0.3.25, MIT, approved, #9904
 npm/npmjs/@jridgewell/trace-mapping/0.3.9, MIT, approved, #9904
 npm/npmjs/@mui/base/5.0.0-beta.40, MIT, approved, #2992
-npm/npmjs/@mui/core-downloads-tracker/5.15.14, MIT, approved, clearlydefined
 npm/npmjs/@mui/core-downloads-tracker/5.15.15, MIT, approved, clearlydefined
-npm/npmjs/@mui/icons-material/5.15.14, MIT AND CC-BY-3.0, approved, #13171
 npm/npmjs/@mui/icons-material/5.15.15, MIT AND CC-BY-3.0, approved, #13171
-npm/npmjs/@mui/material/5.15.14, MIT AND CC-BY-3.0, approved, #13175
 npm/npmjs/@mui/material/5.15.15, MIT AND CC-BY-3.0, approved, #13175
 npm/npmjs/@mui/private-theming/5.15.14, MIT AND CC-BY-3.0, approved, #13174
 npm/npmjs/@mui/styled-engine/5.15.14, MIT AND CC-BY-3.0, approved, #13173
-npm/npmjs/@mui/system/5.15.14, MIT, approved, #13170
 npm/npmjs/@mui/system/5.15.15, MIT, approved, #13170
 npm/npmjs/@mui/types/7.2.14, MIT, approved, clearlydefined
 npm/npmjs/@mui/utils/5.15.14, MIT AND OFL-1.1 AND CC-BY-3.0, approved, #13927
-npm/npmjs/@mui/x-data-grid/6.19.9, MIT, approved, #14027
-npm/npmjs/@mui/x-date-pickers/6.19.9, MIT, approved, #14025
 npm/npmjs/@nodelib/fs.scandir/2.1.5, MIT, approved, clearlydefined
 npm/npmjs/@nodelib/fs.stat/2.0.5, MIT, approved, clearlydefined
 npm/npmjs/@nodelib/fs.walk/1.2.8, MIT, approved, clearlydefined
 npm/npmjs/@popperjs/core/2.11.8, MIT, approved, clearlydefined
+npm/npmjs/@react-aria/ssr/3.9.2, Apache-2.0, approved, clearlydefined
 npm/npmjs/@react-hook/cache/1.1.1, MIT, approved, clearlydefined
 npm/npmjs/@react-hook/latest/1.0.3, MIT, approved, clearlydefined
-npm/npmjs/@reduxjs/toolkit/2.2.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND Apache-2.0, approved, #14170
-npm/npmjs/@remix-run/router/1.15.3, MIT, approved, clearlydefined
+npm/npmjs/@reduxjs/toolkit/2.2.3, MIT AND (BSD-2-Clause AND ISC AND MIT) AND Apache-2.0, approved, #14170
+npm/npmjs/@restart/hooks/0.4.16, MIT, approved, #7049
+npm/npmjs/@restart/ui/1.6.8, MIT, approved, clearlydefined
 npm/npmjs/@rollup/pluginutils/5.1.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-android-arm-eabi/4.13.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-android-arm64/4.13.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-darwin-arm64/4.13.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-darwin-x64/4.13.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-arm-gnueabihf/4.13.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-arm64-gnu/4.13.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-arm64-musl/4.13.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-riscv64-gnu/4.13.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-x64-gnu/4.13.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-x64-musl/4.13.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-win32-arm64-msvc/4.13.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-win32-ia32-msvc/4.13.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-win32-x64-msvc/4.13.0, MIT, approved, clearlydefined
+npm/npmjs/@rollup/rollup-android-arm-eabi/4.14.3, MIT AND (ISC AND MIT), approved, #14395
+npm/npmjs/@rollup/rollup-android-arm64/4.14.3, MIT AND (ISC AND MIT), approved, #14399
+npm/npmjs/@rollup/rollup-darwin-arm64/4.14.3, MIT AND (ISC AND MIT), approved, #14406
+npm/npmjs/@rollup/rollup-darwin-x64/4.14.3, MIT AND (ISC AND MIT), approved, #14394
+npm/npmjs/@rollup/rollup-linux-arm-gnueabihf/4.14.3, MIT AND (ISC AND MIT), approved, #14398
+npm/npmjs/@rollup/rollup-linux-arm-musleabihf/4.14.3, MIT, approved, clearlydefined
+npm/npmjs/@rollup/rollup-linux-arm64-gnu/4.14.3, MIT AND (ISC AND MIT), approved, #14407
+npm/npmjs/@rollup/rollup-linux-arm64-musl/4.14.3, MIT AND (ISC AND MIT), approved, #14396
+npm/npmjs/@rollup/rollup-linux-powerpc64le-gnu/4.14.3, MIT AND (ISC AND MIT), approved, #14403
+npm/npmjs/@rollup/rollup-linux-riscv64-gnu/4.14.3, MIT AND (ISC AND MIT), approved, #14397
+npm/npmjs/@rollup/rollup-linux-s390x-gnu/4.14.3, MIT AND (ISC AND MIT), approved, #14402
+npm/npmjs/@rollup/rollup-linux-x64-gnu/4.14.3, MIT AND (ISC AND MIT), approved, #14400
+npm/npmjs/@rollup/rollup-linux-x64-musl/4.14.3, MIT AND (ISC AND MIT), approved, #14391
+npm/npmjs/@rollup/rollup-win32-arm64-msvc/4.14.3, MIT AND (ISC AND MIT), approved, #14405
+npm/npmjs/@rollup/rollup-win32-ia32-msvc/4.14.3, MIT AND (ISC AND MIT), approved, #14393
+npm/npmjs/@rollup/rollup-win32-x64-msvc/4.14.3, MIT AND (ISC AND MIT), approved, #14392
 npm/npmjs/@sinclair/typebox/0.27.8, MIT, approved, clearlydefined
 npm/npmjs/@sinonjs/commons/3.0.1, BSD-3-Clause, approved, #12905
 npm/npmjs/@sinonjs/fake-timers/10.3.0, BSD-3-Clause, approved, #9214
@@ -725,12 +741,13 @@ npm/npmjs/@svgr/babel-preset/8.1.0, MIT, approved, clearlydefined
 npm/npmjs/@svgr/core/8.1.0, MIT, approved, clearlydefined
 npm/npmjs/@svgr/hast-util-to-babel-ast/8.0.0, MIT, approved, clearlydefined
 npm/npmjs/@svgr/plugin-jsx/8.1.0, MIT, approved, clearlydefined
+npm/npmjs/@swc/helpers/0.5.10, Apache-2.0, approved, #10985
 npm/npmjs/@testing-library/dom/9.3.4, MIT AND (MIT AND WTFPL), approved, #9038
 npm/npmjs/@testing-library/jest-dom/6.4.2, MIT, approved, clearlydefined
-npm/npmjs/@testing-library/react/14.2.2, MIT, approved, #13316
+npm/npmjs/@testing-library/react/14.3.1, MIT, approved, #14385
 npm/npmjs/@testing-library/user-event/14.5.2, MIT, approved, clearlydefined
 npm/npmjs/@tootallnate/once/2.0.0, MIT, approved, clearlydefined
-npm/npmjs/@tsconfig/node10/1.0.9, MIT, approved, clearlydefined
+npm/npmjs/@tsconfig/node10/1.0.11, MIT, approved, clearlydefined
 npm/npmjs/@tsconfig/node12/1.0.11, MIT, approved, clearlydefined
 npm/npmjs/@tsconfig/node14/1.0.3, MIT, approved, clearlydefined
 npm/npmjs/@tsconfig/node16/1.0.4, MIT, approved, clearlydefined
@@ -752,35 +769,36 @@ npm/npmjs/@types/json5/0.0.29, MIT, approved, clearlydefined
 npm/npmjs/@types/lodash.debounce/4.0.9, MIT, approved, clearlydefined
 npm/npmjs/@types/lodash.uniq/4.5.9, MIT, approved, #13930
 npm/npmjs/@types/lodash/4.17.0, MIT, approved, clearlydefined
-npm/npmjs/@types/node/20.11.30, MIT, approved, #13826
+npm/npmjs/@types/node/20.12.7, MIT, approved, clearlydefined
 npm/npmjs/@types/papaparse/5.3.14, MIT, approved, #10964
 npm/npmjs/@types/parse-json/4.0.2, MIT, approved, clearlydefined
-npm/npmjs/@types/prop-types/15.7.11, MIT, approved, clearlydefined
-npm/npmjs/@types/qs/6.9.13, MIT, approved, #13931
-npm/npmjs/@types/react-dom/18.2.22, MIT, approved, #8256
+npm/npmjs/@types/prop-types/15.7.12, MIT, approved, clearlydefined
+npm/npmjs/@types/qs/6.9.15, MIT, approved, #14071
+npm/npmjs/@types/react-dom/18.2.25, MIT, approved, #8256
 npm/npmjs/@types/react-redux/7.1.33, MIT, approved, #10970
 npm/npmjs/@types/react-slick/0.23.13, MIT, approved, #11666
 npm/npmjs/@types/react-transition-group/4.4.10, MIT, approved, #8416
-npm/npmjs/@types/react/18.2.71, MIT, approved, #8234
-npm/npmjs/@types/scheduler/0.16.8, MIT, approved, #7582
+npm/npmjs/@types/react/18.2.79, MIT, approved, #8234
+npm/npmjs/@types/redux-actions/2.6.5, MIT, approved, #10989
 npm/npmjs/@types/semver/7.5.8, MIT, approved, #10842
 npm/npmjs/@types/stack-utils/2.0.3, MIT, approved, clearlydefined
 npm/npmjs/@types/tough-cookie/4.0.5, MIT, approved, #10798
 npm/npmjs/@types/use-sync-external-store/0.0.3, MIT, approved, clearlydefined
+npm/npmjs/@types/warning/3.0.3, MIT, approved, #10988
 npm/npmjs/@types/yargs-parser/21.0.3, MIT, approved, clearlydefined
 npm/npmjs/@types/yargs/17.0.32, MIT, approved, #7054
-npm/npmjs/@typescript-eslint/eslint-plugin/7.3.1, BSD-2-Clause AND (BSD-2-Clause AND ISC AND MIT) AND MIT, approved, #13933
+npm/npmjs/@typescript-eslint/eslint-plugin/7.7.0, BSD-2-Clause AND MIT AND (BSD-2-Clause AND ISC AND MIT), approved, #14387
 npm/npmjs/@typescript-eslint/parser/6.21.0, BSD-2-Clause, approved, clearlydefined
-npm/npmjs/@typescript-eslint/parser/7.3.1, BSD-2-Clause AND (BSD-2-Clause AND ISC AND MIT) AND MIT, approved, #13938
+npm/npmjs/@typescript-eslint/parser/7.7.0, BSD-2-Clause, approved, clearlydefined
 npm/npmjs/@typescript-eslint/scope-manager/6.21.0, MIT, approved, clearlydefined
-npm/npmjs/@typescript-eslint/scope-manager/7.3.1, BSD-2-Clause AND (BSD-2-Clause AND ISC AND MIT) AND MIT, approved, #13937
-npm/npmjs/@typescript-eslint/type-utils/7.3.1, BSD-2-Clause AND (BSD-2-Clause AND ISC AND MIT) AND MIT, approved, #13936
+npm/npmjs/@typescript-eslint/scope-manager/7.7.0, MIT, approved, clearlydefined
+npm/npmjs/@typescript-eslint/type-utils/7.7.0, MIT, approved, clearlydefined
 npm/npmjs/@typescript-eslint/types/6.21.0, MIT, approved, clearlydefined
-npm/npmjs/@typescript-eslint/types/7.3.1, BSD-2-Clause AND (BSD-2-Clause AND ISC AND MIT) AND MIT, approved, #13934
+npm/npmjs/@typescript-eslint/types/7.7.0, MIT, approved, clearlydefined
 npm/npmjs/@typescript-eslint/typescript-estree/6.21.0, BSD-2-Clause AND (BSD-2-Clause AND ISC AND MIT) AND MIT, approved, #13165
-npm/npmjs/@typescript-eslint/typescript-estree/7.3.1, BSD-2-Clause AND (BSD-2-Clause AND ISC AND MIT) AND MIT, approved, #13935
-npm/npmjs/@typescript-eslint/utils/7.3.1, BSD-2-Clause AND (BSD-2-Clause AND ISC AND MIT) AND MIT, approved, #13940
+npm/npmjs/@typescript-eslint/typescript-estree/7.7.0, BSD-2-Clause AND MIT AND (BSD-2-Clause AND ISC AND MIT), approved, #14390
+npm/npmjs/@typescript-eslint/utils/7.7.0, BSD-2-Clause AND MIT AND (BSD-2-Clause AND ISC AND MIT), approved, #14389
 npm/npmjs/@typescript-eslint/visitor-keys/6.21.0, MIT, approved, clearlydefined
-npm/npmjs/@typescript-eslint/visitor-keys/7.3.1, BSD-2-Clause AND (BSD-2-Clause AND ISC AND MIT) AND MIT, approved, #13939
+npm/npmjs/@typescript-eslint/visitor-keys/7.7.0, MIT, approved, clearlydefined
 npm/npmjs/@ungap/structured-clone/1.2.0, ISC, approved, clearlydefined
 npm/npmjs/@vitejs/plugin-react/4.2.1, MIT, approved, clearlydefined

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -17,10 +17,10 @@ npm/npmjs/-/argparse/2.0.1, Python-2.0, approved, CQ22954
 npm/npmjs/-/aria-query/5.1.3, Apache-2.0, approved, clearlydefined
 npm/npmjs/-/aria-query/5.3.0, Apache-2.0, approved, clearlydefined
 npm/npmjs/-/array-buffer-byte-length/1.0.1, MIT, approved, #7548
-npm/npmjs/-/array-includes/3.1.8, MIT, approved, #4577
+npm/npmjs/-/array-includes/3.1.7, MIT, approved, #4577
 npm/npmjs/-/array-union/2.1.0, MIT, approved, clearlydefined
-npm/npmjs/-/array.prototype.findlast/1.2.5, MIT, approved, clearlydefined
-npm/npmjs/-/array.prototype.findlastindex/1.2.5, MIT, approved, #9900
+npm/npmjs/-/array.prototype.findlast/1.2.4, MIT, approved, clearlydefined
+npm/npmjs/-/array.prototype.findlastindex/1.2.4, MIT, approved, #9900
 npm/npmjs/-/array.prototype.flat/1.3.2, MIT, approved, #4574
 npm/npmjs/-/array.prototype.flatmap/1.3.2, MIT, approved, #4651
 npm/npmjs/-/array.prototype.toreversed/1.1.2, MIT, approved, clearlydefined
@@ -28,6 +28,7 @@ npm/npmjs/-/array.prototype.tosorted/1.1.3, MIT, approved, #5051
 npm/npmjs/-/arraybuffer.prototype.slice/1.0.3, MIT, approved, #9657
 npm/npmjs/-/asynckit/0.4.0, MIT, approved, clearlydefined
 npm/npmjs/-/attr-accept/2.2.2, MIT, approved, clearlydefined
+npm/npmjs/-/autosuggest-highlight/3.3.4, MIT, approved, clearlydefined
 npm/npmjs/-/available-typed-arrays/1.0.7, MIT, approved, clearlydefined
 npm/npmjs/-/axios/1.6.8, MIT, approved, #11338
 npm/npmjs/-/babel-jest/29.7.0, MIT, approved, clearlydefined
@@ -39,7 +40,6 @@ npm/npmjs/-/babel-preset-jest/29.6.3, MIT, approved, clearlydefined
 npm/npmjs/-/balanced-match/1.0.2, MIT, approved, clearlydefined
 npm/npmjs/-/base64-js/1.5.1, MIT, approved, clearlydefined
 npm/npmjs/-/binary-extensions/2.3.0, MIT, approved, #13867
-npm/npmjs/-/bootstrap/5.3.3, MIT AND CC-BY-3.0, approved, #9867
 npm/npmjs/-/brace-expansion/1.1.11, MIT, approved, clearlydefined
 npm/npmjs/-/brace-expansion/2.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/braces/3.0.2, MIT, approved, clearlydefined
@@ -49,12 +49,12 @@ npm/npmjs/-/bser/2.1.1, Apache-2.0, approved, clearlydefined
 npm/npmjs/-/buffer-from/1.1.2, MIT, approved, clearlydefined
 npm/npmjs/-/buffer/6.0.3, MIT, approved, clearlydefined
 npm/npmjs/-/builtin-modules/3.3.0, MIT, approved, clearlydefined
-npm/npmjs/-/builtins/5.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/builtins/5.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/call-bind/1.0.7, MIT, approved, #11092
 npm/npmjs/-/callsites/3.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/camelcase/5.3.1, MIT, approved, clearlydefined
 npm/npmjs/-/camelcase/6.3.0, MIT, approved, clearlydefined
-npm/npmjs/-/caniuse-lite/1.0.30001610, CC-BY-4.0, approved, #1196
+npm/npmjs/-/caniuse-lite/1.0.30001599, CC-BY-4.0, approved, #1196
 npm/npmjs/-/chalk/2.4.2, MIT, approved, clearlydefined
 npm/npmjs/-/chalk/3.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/chalk/4.1.2, MIT, approved, clearlydefined
@@ -94,7 +94,7 @@ npm/npmjs/-/dayjs/1.11.10, MIT, approved, #9149
 npm/npmjs/-/debug/3.2.7, MIT, approved, clearlydefined
 npm/npmjs/-/debug/4.3.4, MIT, approved, clearlydefined
 npm/npmjs/-/decimal.js/10.4.3, MIT, approved, clearlydefined
-npm/npmjs/-/dedent/1.5.3, MIT AND (JSON AND MIT), restricted, #14381
+npm/npmjs/-/dedent/1.5.1, MIT, approved, clearlydefined
 npm/npmjs/-/deep-equal/2.2.3, MIT, approved, #8406
 npm/npmjs/-/deep-is/0.1.4, MIT, approved, #2130
 npm/npmjs/-/deepmerge/4.3.1, MIT, approved, #7032
@@ -113,12 +113,14 @@ npm/npmjs/-/dom-accessibility-api/0.6.3, MIT, approved, clearlydefined
 npm/npmjs/-/dom-helpers/5.2.1, MIT, approved, clearlydefined
 npm/npmjs/-/domexception/4.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/dot-case/3.0.4, MIT, approved, clearlydefined
-npm/npmjs/-/electron-to-chromium/1.4.737, ISC, approved, #1950
+npm/npmjs/-/electron-to-chromium/1.4.710, ISC, approved, #1950
 npm/npmjs/-/emittery/0.13.1, MIT, approved, clearlydefined
 npm/npmjs/-/emoji-regex/8.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/enquire.js/2.1.6, MIT, approved, clearlydefined
 npm/npmjs/-/entities/4.5.0, BSD-2-Clause, approved, #7910
 npm/npmjs/-/error-ex/1.3.2, MIT, approved, clearlydefined
-npm/npmjs/-/es-abstract/1.23.3, MIT, approved, clearlydefined
+npm/npmjs/-/es-abstract/1.22.5, MIT, approved, #9656
+npm/npmjs/-/es-abstract/1.23.2, MIT, approved, clearlydefined
 npm/npmjs/-/es-define-property/1.0.0, MIT, approved, #13222
 npm/npmjs/-/es-errors/1.3.0, MIT, approved, #13162
 npm/npmjs/-/es-get-iterator/1.1.3, MIT, approved, clearlydefined
@@ -127,19 +129,19 @@ npm/npmjs/-/es-object-atoms/1.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/es-set-tostringtag/2.0.3, MIT, approved, #6218
 npm/npmjs/-/es-shim-unscopables/1.0.2, MIT, approved, clearlydefined
 npm/npmjs/-/es-to-primitive/1.2.1, MIT, approved, clearlydefined
-npm/npmjs/-/esbuild/0.20.2, MIT, approved, clearlydefined
+npm/npmjs/-/esbuild/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12979
 npm/npmjs/-/escalade/3.1.2, MIT, approved, clearlydefined
 npm/npmjs/-/escape-string-regexp/1.0.5, MIT, approved, clearlydefined
 npm/npmjs/-/escape-string-regexp/2.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/escape-string-regexp/4.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/escodegen/2.1.0, BSD-2-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #9306
-npm/npmjs/-/eslint-compat-utils/0.5.0, MIT, approved, #13999
+npm/npmjs/-/eslint-compat-utils/0.1.2, MIT, approved, clearlydefined
 npm/npmjs/-/eslint-config-love/43.1.0, MIT, approved, #13906
 npm/npmjs/-/eslint-config-prettier/9.1.0, MIT, approved, #11979
 npm/npmjs/-/eslint-config-standard/17.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/eslint-import-resolver-node/0.3.9, MIT, approved, #9923
 npm/npmjs/-/eslint-module-utils/2.8.1, MIT, approved, #8209
-npm/npmjs/-/eslint-plugin-es-x/7.6.0, MIT, approved, #14003
+npm/npmjs/-/eslint-plugin-es-x/7.5.0, MIT, approved, #11867
 npm/npmjs/-/eslint-plugin-import/2.29.1, MIT, approved, #11187
 npm/npmjs/-/eslint-plugin-n/16.6.2, MIT, approved, #12657
 npm/npmjs/-/eslint-plugin-promise/6.1.1, ISC, approved, clearlydefined
@@ -180,7 +182,6 @@ npm/npmjs/-/fsevents/2.3.3, MIT, approved, #2967
 npm/npmjs/-/function-bind/1.1.2, MIT, approved, #11063
 npm/npmjs/-/function.prototype.name/1.1.6, MIT, approved, #10255
 npm/npmjs/-/functions-have-names/1.2.3, MIT, approved, clearlydefined
-npm/npmjs/-/fuse.js/3.6.1, Apache-2.0, approved, clearlydefined
 npm/npmjs/-/gensync/1.0.0-beta.2, MIT, approved, clearlydefined
 npm/npmjs/-/get-caller-file/2.0.5, ISC, approved, clearlydefined
 npm/npmjs/-/get-intrinsic/1.2.4, MIT, approved, #8453
@@ -208,8 +209,6 @@ npm/npmjs/-/has-proto/1.0.3, MIT, approved, #6175
 npm/npmjs/-/has-symbols/1.0.3, MIT, approved, clearlydefined
 npm/npmjs/-/has-tostringtag/1.0.2, MIT, approved, #13161
 npm/npmjs/-/hasown/2.0.2, MIT, approved, #11097
-npm/npmjs/-/history/4.10.1, MIT, approved, clearlydefined
-npm/npmjs/-/history/5.3.0, MIT, approved, clearlydefined
 npm/npmjs/-/hoist-non-react-statics/3.3.2, BSD-3-Clause, approved, clearlydefined
 npm/npmjs/-/html-encoding-sniffer/3.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/html-escaper/2.0.2, MIT, approved, clearlydefined
@@ -218,8 +217,8 @@ npm/npmjs/-/http-proxy-agent/5.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/https-proxy-agent/5.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/human-signals/2.1.0, Apache-2.0, approved, clearlydefined
 npm/npmjs/-/husky/9.0.11, MIT, approved, clearlydefined
-npm/npmjs/-/i18next-browser-languagedetector/7.2.1, MIT, approved, clearlydefined
-npm/npmjs/-/i18next/23.11.2, MIT, approved, #14383
+npm/npmjs/-/i18next-browser-languagedetector/7.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/i18next/23.10.1, MIT, approved, #13869
 npm/npmjs/-/iconv-lite/0.6.3, MIT, approved, clearlydefined
 npm/npmjs/-/identity-obj-proxy/3.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/ieee754/1.2.1, BSD-3-Clause, approved, clearlydefined
@@ -233,7 +232,6 @@ npm/npmjs/-/indent-string/4.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/inflight/1.0.6, ISC, approved, clearlydefined
 npm/npmjs/-/inherits/2.0.4, ISC, approved, clearlydefined
 npm/npmjs/-/internal-slot/1.0.7, MIT, approved, #7118
-npm/npmjs/-/invariant/2.2.4, MIT, approved, #1034
 npm/npmjs/-/is-arguments/1.1.1, MIT, approved, clearlydefined
 npm/npmjs/-/is-array-buffer/3.0.4, MIT, approved, #6248
 npm/npmjs/-/is-arrayish/0.2.1, MIT, approved, clearlydefined
@@ -268,7 +266,6 @@ npm/npmjs/-/is-typed-array/1.1.13, MIT, approved, #4853
 npm/npmjs/-/is-weakmap/2.0.2, MIT, approved, clearlydefined
 npm/npmjs/-/is-weakref/1.0.2, MIT, approved, clearlydefined
 npm/npmjs/-/is-weakset/2.0.3, MIT, approved, clearlydefined
-npm/npmjs/-/isarray/0.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/isarray/2.0.5, MIT, approved, clearlydefined
 npm/npmjs/-/isexe/2.0.0, ISC, approved, clearlydefined
 npm/npmjs/-/istanbul-lib-coverage/3.2.2, BSD-3-Clause, approved, clearlydefined
@@ -305,7 +302,8 @@ npm/npmjs/-/jest-validate/29.7.0, MIT, approved, clearlydefined
 npm/npmjs/-/jest-watcher/29.7.0, MIT, approved, clearlydefined
 npm/npmjs/-/jest-worker/29.7.0, MIT, approved, clearlydefined
 npm/npmjs/-/jest/29.7.0, MIT, approved, clearlydefined
-npm/npmjs/-/js-sha256/0.11.0, MIT, approved, clearlydefined
+npm/npmjs/-/jquery/3.7.1, MIT, approved, clearlydefined
+npm/npmjs/-/js-sha256/0.10.1, MIT, approved, clearlydefined
 npm/npmjs/-/js-tokens/4.0.0, MIT, approved, #2401
 npm/npmjs/-/js-yaml/3.14.1, MIT, approved, clearlydefined
 npm/npmjs/-/js-yaml/4.1.0, MIT, approved, clearlydefined
@@ -315,12 +313,12 @@ npm/npmjs/-/json-buffer/3.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/json-parse-even-better-errors/2.3.1, MIT, approved, clearlydefined
 npm/npmjs/-/json-schema-traverse/0.4.1, MIT, approved, clearlydefined
 npm/npmjs/-/json-stable-stringify-without-jsonify/1.0.1, MIT, approved, clearlydefined
+npm/npmjs/-/json2mq/0.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/json5/1.0.2, MIT, approved, CQ22351
 npm/npmjs/-/json5/2.2.3, MIT, approved, #2126
 npm/npmjs/-/jsx-ast-utils/3.3.5, MIT, approved, #9209
-npm/npmjs/-/just-curry-it/5.3.0, MIT, approved, clearlydefined
 npm/npmjs/-/jwt-decode/4.0.0, MIT, approved, clearlydefined
-npm/npmjs/-/keycloak-js/24.0.2, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/keycloak-js/23.0.7, Apache-2.0 AND MIT AND EPL-1.0 AND LicenseRef-scancode-oasis-ws-security-spec AND W3C AND LicenseRef-scancode-ws-policy-specification AND W3C AND W3C-19980720 AND (AFL-2.1 OR LGPL-2.0-only) AND (Apache-2.0 AND MIT) AND (Apache-2.0 AND MIT), approved, #11737
 npm/npmjs/-/keyv/4.5.4, MIT, approved, #4674
 npm/npmjs/-/kleur/3.0.3, MIT, approved, clearlydefined
 npm/npmjs/-/leven/3.1.0, MIT, approved, clearlydefined
@@ -350,15 +348,13 @@ npm/npmjs/-/mime-db/1.52.0, MIT, approved, clearlydefined
 npm/npmjs/-/mime-types/2.1.35, MIT, approved, clearlydefined
 npm/npmjs/-/mimic-fn/2.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/min-indent/1.0.1, MIT, approved, clearlydefined
-npm/npmjs/-/mini-create-react-context/0.4.1, MIT, approved, clearlydefined
 npm/npmjs/-/minimatch/3.1.2, ISC, approved, clearlydefined
 npm/npmjs/-/minimatch/9.0.3, ISC, approved, #9190
-npm/npmjs/-/minimatch/9.0.4, ISC, approved, #9190
 npm/npmjs/-/minimist/1.2.8, MIT, approved, #5886
 npm/npmjs/-/ms/2.1.2, MIT, approved, #5895
 npm/npmjs/-/ms/2.1.3, MIT, approved, #5895
 npm/npmjs/-/nanoid/3.3.7, MIT, approved, #7571
-npm/npmjs/-/nanoid/5.0.7, MIT, approved, clearlydefined
+npm/npmjs/-/nanoid/5.0.6, MIT, approved, clearlydefined
 npm/npmjs/-/natural-compare/1.4.0, MIT, approved, clearlydefined
 npm/npmjs/-/no-case/3.0.4, MIT, approved, clearlydefined
 npm/npmjs/-/node-int64/0.4.0, MIT, approved, clearlydefined
@@ -374,7 +370,7 @@ npm/npmjs/-/object.assign/4.1.5, MIT, approved, #3232
 npm/npmjs/-/object.entries/1.1.8, MIT, approved, #4671
 npm/npmjs/-/object.fromentries/2.0.8, MIT, approved, #4600
 npm/npmjs/-/object.groupby/1.0.3, MIT, approved, #10360
-npm/npmjs/-/object.hasown/1.1.4, MIT, approved, #4667
+npm/npmjs/-/object.hasown/1.1.3, MIT, approved, #4667
 npm/npmjs/-/object.values/1.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/once/1.4.0, ISC, approved, clearlydefined
 npm/npmjs/-/onetime/5.1.2, MIT, approved, clearlydefined
@@ -392,7 +388,6 @@ npm/npmjs/-/path-exists/4.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/path-is-absolute/1.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/path-key/3.1.1, MIT, approved, clearlydefined
 npm/npmjs/-/path-parse/1.0.7, MIT, approved, clearlydefined
-npm/npmjs/-/path-to-regexp/1.8.0, MIT, approved, clearlydefined
 npm/npmjs/-/path-type/4.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/phone/3.1.42, MIT, approved, #10500
 npm/npmjs/-/picocolors/1.0.0, ISC, approved, clearlydefined
@@ -400,74 +395,65 @@ npm/npmjs/-/picomatch/2.3.1, MIT, approved, clearlydefined
 npm/npmjs/-/pirates/4.0.6, MIT, approved, #680
 npm/npmjs/-/pkg-dir/4.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/possible-typed-array-names/1.0.0, MIT, approved, clearlydefined
-npm/npmjs/-/postcss/8.4.38, MIT, approved, #3545
+npm/npmjs/-/postcss/8.4.36, MIT, approved, #3545
 npm/npmjs/-/prelude-ls/1.2.1, MIT, approved, clearlydefined
 npm/npmjs/-/prettier/3.2.5, MIT AND ISC AND BSD-2-Clause AND BSD-3-Clause AND Apache-2.0, approved, #13320
 npm/npmjs/-/pretty-format/27.5.1, 0BSD AND Apache-2.0 AND BSD-2-Clause AND MIT, approved, #1948
 npm/npmjs/-/pretty-format/29.7.0, MIT, approved, clearlydefined
 npm/npmjs/-/prompts/2.4.2, MIT, approved, clearlydefined
-npm/npmjs/-/prop-types-extra/1.1.1, , approved, CQ22354
 npm/npmjs/-/prop-types/15.8.1, MIT, approved, clearlydefined
 npm/npmjs/-/proxy-from-env/1.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/psl/1.9.0, MIT AND CC0-1.0, approved, #3080
 npm/npmjs/-/punycode/2.3.1, MIT, approved, #6373
-npm/npmjs/-/pure-rand/6.1.0, MIT, approved, clearlydefined
-npm/npmjs/-/qs/6.12.1, BSD-3-Clause, approved, #14380
+npm/npmjs/-/pure-rand/6.0.4, MIT AND (BSD-2-Clause AND ISC AND MIT), approved, #8423
+npm/npmjs/-/qs/6.12.0, BSD-3-Clause, approved, clearlydefined
 npm/npmjs/-/querystringify/2.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/queue-microtask/1.2.3, MIT, approved, clearlydefined
-npm/npmjs/-/react-bootstrap/2.10.2, MIT AND CC-PDDC, restricted, #14382
-npm/npmjs/-/react-datepicker/6.8.0, MIT AND BSD-3-Clause, approved, #14379
 npm/npmjs/-/react-dom/18.2.0, MIT, approved, clearlydefined
-npm/npmjs/-/react-dropzone-uploader/2.11.0, MIT, approved, clearlydefined
 npm/npmjs/-/react-dropzone/14.2.3, MIT, approved, clearlydefined
 npm/npmjs/-/react-fast-compare/3.2.2, MIT, approved, clearlydefined
-npm/npmjs/-/react-hook-form/7.51.3, MIT, approved, #13909
+npm/npmjs/-/react-hook-form/7.51.1, MIT, approved, #13909
 npm/npmjs/-/react-i18next/14.1.0, MIT AND Apache-2.0, approved, #13870
-npm/npmjs/-/react-icons/5.1.0, Apache-2.0 AND CC-BY-3.0 AND CC-BY-4.0 AND CC-BY-SA-3.0 AND CC0-1.0 AND ISC AND MIT AND MPL-2.0 AND OFL-1.1 AND MIT AND (Apache-2.0 AND CC-BY-3.0 AND CC-BY-4.0 AND CC-BY-SA-3.0 AND CC0-1.0 AND MIT AND OFL-1.1), approved, #14386
 npm/npmjs/-/react-is/16.13.1, MIT, approved, clearlydefined
 npm/npmjs/-/react-is/17.0.2, MIT, approved, clearlydefined
 npm/npmjs/-/react-is/18.2.0, MIT, approved, clearlydefined
-npm/npmjs/-/react-lifecycles-compat/3.0.4, MIT, approved, clearlydefined
-npm/npmjs/-/react-onclickoutside/6.13.0, MIT, approved, clearlydefined
-npm/npmjs/-/react-player/2.16.0, MIT, approved, #14388
-npm/npmjs/-/react-redux/9.1.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-3-Clause, approved, #13913
+npm/npmjs/-/react-player/2.15.1, MIT, approved, #13914
+npm/npmjs/-/react-redux/9.1.0, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-3-Clause, approved, #13913
 npm/npmjs/-/react-refresh/0.14.0, MIT, approved, clearlydefined
-npm/npmjs/-/react-router-dom/5.3.3, MIT AND BSD-3-Clause, approved, #3023
-npm/npmjs/-/react-router/5.3.3, MIT AND BSD-3-Clause AND CC-BY-4.0, approved, #3024
-npm/npmjs/-/react-search-input/0.11.3, MIT, approved, clearlydefined
-npm/npmjs/-/react-toastify/10.0.5, MIT, approved, #13093
-npm/npmjs/-/react-tooltip/5.26.3, MIT, approved, clearlydefined
+npm/npmjs/-/react-router-dom/6.22.3, MIT, approved, #13333
+npm/npmjs/-/react-router/6.22.3, MIT, approved, clearlydefined
+npm/npmjs/-/react-slick/0.30.2, MIT, approved, #14009
 npm/npmjs/-/react-transition-group/4.4.5, BSD-3-Clause, approved, CQ22955
 npm/npmjs/-/react/18.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/readdirp/3.6.0, MIT, approved, #2977
 npm/npmjs/-/redent/3.0.0, MIT, approved, clearlydefined
-npm/npmjs/-/reduce-reducers/1.0.4, MIT, approved, clearlydefined
-npm/npmjs/-/redux-actions/3.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/redux-thunk/3.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/redux/4.2.1, CC0-1.0 AND MIT, approved, #7046
 npm/npmjs/-/redux/5.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/reflect.getprototypeof/1.0.6, MIT, approved, #13910
 npm/npmjs/-/regenerator-runtime/0.14.1, MIT, approved, #9897
 npm/npmjs/-/regexp.prototype.flags/1.5.2, MIT, approved, #8199
+npm/npmjs/-/remove-accents/0.4.4, MIT, approved, clearlydefined
 npm/npmjs/-/require-directory/2.1.1, MIT, approved, clearlydefined
 npm/npmjs/-/requires-port/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/reselect/4.1.8, MIT, approved, clearlydefined
 npm/npmjs/-/reselect/5.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/resize-observer-polyfill/1.5.1, MIT, approved, clearlydefined
 npm/npmjs/-/resolve-cwd/3.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/resolve-from/4.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/resolve-from/5.0.0, MIT, approved, clearlydefined
-npm/npmjs/-/resolve-pathname/3.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/resolve-pkg-maps/1.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/resolve.exports/2.0.2, MIT, approved, clearlydefined
 npm/npmjs/-/resolve/1.22.8, MIT AND ISC, approved, #2409
 npm/npmjs/-/resolve/2.0.0-next.5, MIT AND ISC, approved, #3078
 npm/npmjs/-/reusify/1.0.4, MIT, approved, clearlydefined
 npm/npmjs/-/rimraf/3.0.2, ISC, approved, clearlydefined
-npm/npmjs/-/rollup/4.14.3, MIT, approved, clearlydefined
+npm/npmjs/-/rollup/4.13.0, MIT, approved, clearlydefined
 npm/npmjs/-/run-parallel/1.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/safe-array-concat/1.1.2, MIT, approved, clearlydefined
 npm/npmjs/-/safe-regex-test/1.0.3, MIT, approved, clearlydefined
 npm/npmjs/-/safer-buffer/2.1.2, MIT, approved, clearlydefined
-npm/npmjs/-/sass/1.75.0, MIT, approved, clearlydefined
+npm/npmjs/-/sass/1.72.0, MIT, approved, clearlydefined
 npm/npmjs/-/saxes/6.0.0, ISC, approved, clearlydefined
 npm/npmjs/-/scheduler/0.23.0, MIT, approved, clearlydefined
 npm/npmjs/-/semver/6.3.1, ISC, approved, clearlydefined
@@ -480,6 +466,7 @@ npm/npmjs/-/side-channel/1.0.6, MIT, approved, clearlydefined
 npm/npmjs/-/signal-exit/3.0.7, ISC, approved, #5892
 npm/npmjs/-/sisteransi/1.0.5, MIT, approved, clearlydefined
 npm/npmjs/-/slash/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/slick-carousel/1.8.1, MIT, approved, #2986
 npm/npmjs/-/snake-case/3.0.4, MIT, approved, clearlydefined
 npm/npmjs/-/source-map-js/1.2.0, BSD-3-Clause, approved, #13911
 npm/npmjs/-/source-map-support/0.5.13, MIT, approved, clearlydefined
@@ -488,12 +475,13 @@ npm/npmjs/-/source-map/0.6.1, BSD-3-Clause, approved, #2417
 npm/npmjs/-/sprintf-js/1.0.3, BSD-3-Clause, approved, #949
 npm/npmjs/-/stack-utils/2.0.6, MIT, approved, clearlydefined
 npm/npmjs/-/stop-iteration-iterator/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/string-convert/0.2.1, MIT, approved, clearlydefined
 npm/npmjs/-/string-length/4.0.2, MIT, approved, clearlydefined
 npm/npmjs/-/string-width/4.2.3, MIT, approved, clearlydefined
-npm/npmjs/-/string.prototype.matchall/4.0.11, MIT, approved, #4571
+npm/npmjs/-/string.prototype.matchall/4.0.10, MIT, approved, #4571
 npm/npmjs/-/string.prototype.trim/1.2.9, MIT, approved, #10361
 npm/npmjs/-/string.prototype.trimend/1.0.8, MIT, approved, #4564
-npm/npmjs/-/string.prototype.trimstart/1.0.8, MIT, approved, #4647
+npm/npmjs/-/string.prototype.trimstart/1.0.7, MIT, approved, #4647
 npm/npmjs/-/strip-ansi/6.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/strip-bom/3.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/strip-bom/4.0.0, MIT, approved, clearlydefined
@@ -507,11 +495,8 @@ npm/npmjs/-/supports-color/8.1.1, MIT, approved, clearlydefined
 npm/npmjs/-/supports-preserve-symlinks-flag/1.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/svg-parser/2.0.4, MIT, approved, clearlydefined
 npm/npmjs/-/symbol-tree/3.2.4, MIT, approved, clearlydefined
-npm/npmjs/-/tabbable/6.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/test-exclude/6.0.0, ISC, approved, clearlydefined
 npm/npmjs/-/text-table/0.2.0, MIT, approved, clearlydefined
-npm/npmjs/-/tiny-invariant/1.3.3, MIT, approved, clearlydefined
-npm/npmjs/-/tiny-warning/1.0.3, MIT, approved, clearlydefined
 npm/npmjs/-/tmpl/1.0.5, BSD-3-Clause, approved, clearlydefined
 npm/npmjs/-/to-fast-properties/2.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/to-regex-range/5.0.1, MIT, approved, clearlydefined
@@ -530,28 +515,23 @@ npm/npmjs/-/type-fest/0.21.3, MIT OR (CC0-1.0 AND MIT), approved, clearlydefined
 npm/npmjs/-/typed-array-buffer/1.0.2, MIT, approved, #9658
 npm/npmjs/-/typed-array-byte-length/1.0.1, MIT, approved, #9659
 npm/npmjs/-/typed-array-byte-offset/1.0.2, MIT, approved, #9407
-npm/npmjs/-/typed-array-length/1.0.6, MIT, approved, #6246
-npm/npmjs/-/typescript/5.4.5, Apache-2.0 AND MIT AND CC-BY-4.0 AND Unicode-DFS-2016 AND W3C-20150513, approved, #13647
+npm/npmjs/-/typed-array-length/1.0.5, MIT, approved, #6246
+npm/npmjs/-/typescript/5.4.3, Apache-2.0 AND MIT AND CC-BY-4.0 AND Unicode-DFS-2016 AND W3C-20150513, approved, #13647
 npm/npmjs/-/unbox-primitive/1.0.2, MIT, approved, clearlydefined
-npm/npmjs/-/uncontrollable/7.2.1, MIT AND BSD-3-Clause, approved, #3025
-npm/npmjs/-/uncontrollable/8.0.4, MIT, approved, clearlydefined
 npm/npmjs/-/undici-types/5.26.5, MIT, approved, clearlydefined
 npm/npmjs/-/universalify/0.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/update-browserslist-db/1.0.13, MIT, approved, #8237
 npm/npmjs/-/uri-js/4.4.1, BSD-2-Clause, approved, #1086
 npm/npmjs/-/url-parse/1.5.10, MIT, approved, clearlydefined
 npm/npmjs/-/use-sync-external-store/1.2.0, MIT, approved, clearlydefined
-npm/npmjs/-/uuid/9.0.1, MIT AND (BSD-3-Clause AND MIT), approved, #6869
 npm/npmjs/-/v8-compile-cache-lib/3.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/v8-to-istanbul/9.2.0, ISC, approved, clearlydefined
-npm/npmjs/-/value-equal/1.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/vite-plugin-svgr/4.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/vite-tsconfig-paths/4.3.2, MIT, approved, clearlydefined
-npm/npmjs/-/vite/5.2.9, MIT AND (ISC AND MIT) AND (Apache-2.0 AND BSD-2-Clause AND CC0-1.0 AND ISC AND MIT) AND (BSD-3-Clause AND MIT) AND ISC AND (BSD-2-Clause AND BSD-3-Clause), approved, #13953
+npm/npmjs/-/vite/5.1.6, MIT AND (ISC AND MIT) AND (Apache-2.0 AND BSD-2-Clause AND CC0-1.0 AND ISC AND MIT) AND (BSD-3-Clause AND MIT) AND ISC AND (BSD-2-Clause AND BSD-3-Clause), approved, #13202
 npm/npmjs/-/void-elements/3.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/w3c-xmlserializer/4.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/walker/1.0.8, Apache-2.0, approved, clearlydefined
-npm/npmjs/-/warning/4.0.3, MIT, approved, CQ22359
 npm/npmjs/-/webidl-conversions/7.0.0, BSD-2-Clause, approved, clearlydefined
 npm/npmjs/-/whatwg-encoding/2.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/whatwg-mimetype/3.0.0, MIT, approved, clearlydefined
@@ -578,15 +558,15 @@ npm/npmjs/-/yocto-queue/0.1.0, MIT, approved, clearlydefined
 npm/npmjs/@aashutoshrathi/word-wrap/1.2.6, MIT, approved, #9212
 npm/npmjs/@adobe/css-tools/4.3.3, MIT, approved, #9985
 npm/npmjs/@ampproject/remapping/2.3.0, Apache-2.0, approved, clearlydefined
-npm/npmjs/@babel/code-frame/7.24.2, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13943
-npm/npmjs/@babel/compat-data/7.24.4, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13915
-npm/npmjs/@babel/core/7.24.4, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13942
-npm/npmjs/@babel/generator/7.24.4, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13919
+npm/npmjs/@babel/code-frame/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13943
+npm/npmjs/@babel/compat-data/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13915
+npm/npmjs/@babel/core/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13942
+npm/npmjs/@babel/generator/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13919
 npm/npmjs/@babel/helper-compilation-targets/7.23.6, MIT, approved, clearlydefined
 npm/npmjs/@babel/helper-environment-visitor/7.22.20, MIT, approved, #8934
 npm/npmjs/@babel/helper-function-name/7.23.0, MIT, approved, clearlydefined
 npm/npmjs/@babel/helper-hoist-variables/7.22.5, MIT, approved, #8957
-npm/npmjs/@babel/helper-module-imports/7.24.3, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13944
+npm/npmjs/@babel/helper-module-imports/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13944
 npm/npmjs/@babel/helper-module-transforms/7.23.3, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #11537
 npm/npmjs/@babel/helper-plugin-utils/7.24.0, MIT, approved, clearlydefined
 npm/npmjs/@babel/helper-simple-access/7.22.5, MIT, approved, #9048
@@ -594,9 +574,9 @@ npm/npmjs/@babel/helper-split-export-declaration/7.22.6, MIT, approved, #8938
 npm/npmjs/@babel/helper-string-parser/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13923
 npm/npmjs/@babel/helper-validator-identifier/7.22.20, MIT, approved, #8955
 npm/npmjs/@babel/helper-validator-option/7.23.5, MIT, approved, clearlydefined
-npm/npmjs/@babel/helpers/7.24.4, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13922
-npm/npmjs/@babel/highlight/7.24.2, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13941
-npm/npmjs/@babel/parser/7.24.4, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13492
+npm/npmjs/@babel/helpers/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13922
+npm/npmjs/@babel/highlight/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13941
+npm/npmjs/@babel/parser/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13492
 npm/npmjs/@babel/plugin-syntax-async-generators/7.8.4, MIT, approved, #1973
 npm/npmjs/@babel/plugin-syntax-bigint/7.8.3, MIT, approved, clearlydefined
 npm/npmjs/@babel/plugin-syntax-class-properties/7.12.13, MIT, approved, clearlydefined
@@ -613,48 +593,52 @@ npm/npmjs/@babel/plugin-syntax-top-level-await/7.14.5, MIT, approved, clearlydef
 npm/npmjs/@babel/plugin-syntax-typescript/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13924
 npm/npmjs/@babel/plugin-transform-react-jsx-self/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13928
 npm/npmjs/@babel/plugin-transform-react-jsx-source/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13925
-npm/npmjs/@babel/runtime/7.24.4, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13900
+npm/npmjs/@babel/runtime/7.23.6, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #10718
+npm/npmjs/@babel/runtime/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13900
 npm/npmjs/@babel/template/7.24.0, MIT, approved, clearlydefined
 npm/npmjs/@babel/traverse/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13926
 npm/npmjs/@babel/types/7.24.0, MIT, approved, clearlydefined
 npm/npmjs/@bcoe/v8-coverage/0.2.3, ISC AND MIT, approved, clearlydefined
+npm/npmjs/@catena-x/portal-shared-components/3.0.4, Apache-2.0 AND CC-BY-4.0 AND OFL-1.1, approved, #14247
 npm/npmjs/@cspotcode/source-map-support/0.8.1, MIT, approved, clearlydefined
+npm/npmjs/@date-io/core/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/@date-io/date-fns/3.0.0, MIT, approved, #14023
 npm/npmjs/@emotion/babel-plugin/11.11.0, MIT, approved, #8386
 npm/npmjs/@emotion/cache/11.11.0, MIT, approved, #8401
 npm/npmjs/@emotion/hash/0.9.1, MIT, approved, #8394
 npm/npmjs/@emotion/is-prop-valid/1.2.2, MIT, approved, #8392
 npm/npmjs/@emotion/memoize/0.8.1, MIT, approved, #8408
 npm/npmjs/@emotion/react/11.11.4, MIT AND (BSD-3-Clause AND MIT), approved, #8931
-npm/npmjs/@emotion/serialize/1.1.4, MIT, approved, #8417
+npm/npmjs/@emotion/serialize/1.1.3, MIT, approved, #8417
 npm/npmjs/@emotion/sheet/1.2.2, MIT, approved, #8389
-npm/npmjs/@emotion/styled/11.11.5, MIT, approved, clearlydefined
+npm/npmjs/@emotion/styled/11.11.0, MIT, approved, clearlydefined
 npm/npmjs/@emotion/unitless/0.8.1, MIT, approved, #8403
 npm/npmjs/@emotion/use-insertion-effect-with-fallbacks/1.0.1, MIT, approved, #8419
 npm/npmjs/@emotion/utils/1.2.1, MIT, approved, #8415
 npm/npmjs/@emotion/weak-memoize/0.3.1, MIT, approved, #8402
-npm/npmjs/@esbuild/aix-ppc64/0.20.2, MIT, approved, clearlydefined
-npm/npmjs/@esbuild/android-arm/0.20.2, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #13952
-npm/npmjs/@esbuild/android-arm64/0.20.2, MIT, approved, clearlydefined
-npm/npmjs/@esbuild/android-x64/0.20.2, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #13954
-npm/npmjs/@esbuild/darwin-arm64/0.20.2, MIT, approved, clearlydefined
-npm/npmjs/@esbuild/darwin-x64/0.20.2, MIT, approved, clearlydefined
-npm/npmjs/@esbuild/freebsd-arm64/0.20.2, MIT, approved, clearlydefined
-npm/npmjs/@esbuild/freebsd-x64/0.20.2, MIT, approved, clearlydefined
-npm/npmjs/@esbuild/linux-arm/0.20.2, MIT, approved, clearlydefined
-npm/npmjs/@esbuild/linux-arm64/0.20.2, MIT, approved, clearlydefined
-npm/npmjs/@esbuild/linux-ia32/0.20.2, MIT, approved, clearlydefined
-npm/npmjs/@esbuild/linux-loong64/0.20.2, MIT, approved, clearlydefined
-npm/npmjs/@esbuild/linux-mips64el/0.20.2, MIT, approved, clearlydefined
-npm/npmjs/@esbuild/linux-ppc64/0.20.2, MIT, approved, clearlydefined
-npm/npmjs/@esbuild/linux-riscv64/0.20.2, MIT, approved, clearlydefined
-npm/npmjs/@esbuild/linux-s390x/0.20.2, MIT, approved, clearlydefined
-npm/npmjs/@esbuild/linux-x64/0.20.2, MIT, approved, clearlydefined
-npm/npmjs/@esbuild/netbsd-x64/0.20.2, MIT, approved, clearlydefined
-npm/npmjs/@esbuild/openbsd-x64/0.20.2, MIT, approved, clearlydefined
-npm/npmjs/@esbuild/sunos-x64/0.20.2, MIT, approved, clearlydefined
-npm/npmjs/@esbuild/win32-arm64/0.20.2, MIT, approved, clearlydefined
-npm/npmjs/@esbuild/win32-ia32/0.20.2, MIT, approved, clearlydefined
-npm/npmjs/@esbuild/win32-x64/0.20.2, MIT, approved, clearlydefined
+npm/npmjs/@esbuild/aix-ppc64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12976
+npm/npmjs/@esbuild/android-arm/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #11629
+npm/npmjs/@esbuild/android-arm64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12967
+npm/npmjs/@esbuild/android-x64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #11638
+npm/npmjs/@esbuild/darwin-arm64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12987
+npm/npmjs/@esbuild/darwin-x64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12974
+npm/npmjs/@esbuild/freebsd-arm64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12973
+npm/npmjs/@esbuild/freebsd-x64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12988
+npm/npmjs/@esbuild/linux-arm/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12968
+npm/npmjs/@esbuild/linux-arm64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12985
+npm/npmjs/@esbuild/linux-ia32/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12972
+npm/npmjs/@esbuild/linux-loong64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12971
+npm/npmjs/@esbuild/linux-mips64el/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12977
+npm/npmjs/@esbuild/linux-ppc64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12966
+npm/npmjs/@esbuild/linux-riscv64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12986
+npm/npmjs/@esbuild/linux-s390x/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12975
+npm/npmjs/@esbuild/linux-x64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12980
+npm/npmjs/@esbuild/netbsd-x64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12959
+npm/npmjs/@esbuild/openbsd-x64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12981
+npm/npmjs/@esbuild/sunos-x64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12970
+npm/npmjs/@esbuild/win32-arm64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12960
+npm/npmjs/@esbuild/win32-ia32/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12969
+npm/npmjs/@esbuild/win32-x64/0.19.12, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #12961
 npm/npmjs/@eslint-community/eslint-utils/4.4.0, MIT, approved, #8032
 npm/npmjs/@eslint-community/regexpp/4.10.0, MIT, approved, clearlydefined
 npm/npmjs/@eslint/eslintrc/2.1.4, MIT, approved, #9908
@@ -662,12 +646,11 @@ npm/npmjs/@eslint/js/8.57.0, MIT, approved, clearlydefined
 npm/npmjs/@floating-ui/core/1.6.0, MIT, approved, clearlydefined
 npm/npmjs/@floating-ui/dom/1.6.3, MIT, approved, clearlydefined
 npm/npmjs/@floating-ui/react-dom/2.0.8, MIT, approved, clearlydefined
-npm/npmjs/@floating-ui/react/0.26.12, MIT AND ISC AND (CC-BY-4.0 AND MIT), approved, #14384
 npm/npmjs/@floating-ui/utils/0.2.1, MIT, approved, clearlydefined
 npm/npmjs/@hookform/error-message/2.0.1, MIT, approved, clearlydefined
 npm/npmjs/@humanwhocodes/config-array/0.11.14, Apache-2.0, approved, #5876
 npm/npmjs/@humanwhocodes/module-importer/1.0.1, Apache-2.0, approved, clearlydefined
-npm/npmjs/@humanwhocodes/object-schema/2.0.3, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/@humanwhocodes/object-schema/2.0.2, BSD-3-Clause, approved, clearlydefined
 npm/npmjs/@istanbuljs/load-nyc-config/1.1.0, ISC, approved, clearlydefined
 npm/npmjs/@istanbuljs/schema/0.1.3, MIT, approved, clearlydefined
 npm/npmjs/@jest/console/29.7.0, MIT, approved, clearlydefined
@@ -691,41 +674,42 @@ npm/npmjs/@jridgewell/sourcemap-codec/1.4.15, MIT, approved, clearlydefined
 npm/npmjs/@jridgewell/trace-mapping/0.3.25, MIT, approved, #9904
 npm/npmjs/@jridgewell/trace-mapping/0.3.9, MIT, approved, #9904
 npm/npmjs/@mui/base/5.0.0-beta.40, MIT, approved, #2992
+npm/npmjs/@mui/core-downloads-tracker/5.15.14, MIT, approved, clearlydefined
 npm/npmjs/@mui/core-downloads-tracker/5.15.15, MIT, approved, clearlydefined
+npm/npmjs/@mui/icons-material/5.15.14, MIT AND CC-BY-3.0, approved, #13171
 npm/npmjs/@mui/icons-material/5.15.15, MIT AND CC-BY-3.0, approved, #13171
+npm/npmjs/@mui/material/5.15.14, MIT AND CC-BY-3.0, approved, #13175
 npm/npmjs/@mui/material/5.15.15, MIT AND CC-BY-3.0, approved, #13175
 npm/npmjs/@mui/private-theming/5.15.14, MIT AND CC-BY-3.0, approved, #13174
 npm/npmjs/@mui/styled-engine/5.15.14, MIT AND CC-BY-3.0, approved, #13173
+npm/npmjs/@mui/system/5.15.14, MIT, approved, #13170
 npm/npmjs/@mui/system/5.15.15, MIT, approved, #13170
 npm/npmjs/@mui/types/7.2.14, MIT, approved, clearlydefined
 npm/npmjs/@mui/utils/5.15.14, MIT AND OFL-1.1 AND CC-BY-3.0, approved, #13927
+npm/npmjs/@mui/x-data-grid/6.19.9, MIT, approved, #14027
+npm/npmjs/@mui/x-date-pickers/6.19.9, MIT, approved, #14025
 npm/npmjs/@nodelib/fs.scandir/2.1.5, MIT, approved, clearlydefined
 npm/npmjs/@nodelib/fs.stat/2.0.5, MIT, approved, clearlydefined
 npm/npmjs/@nodelib/fs.walk/1.2.8, MIT, approved, clearlydefined
 npm/npmjs/@popperjs/core/2.11.8, MIT, approved, clearlydefined
-npm/npmjs/@react-aria/ssr/3.9.2, Apache-2.0, approved, clearlydefined
 npm/npmjs/@react-hook/cache/1.1.1, MIT, approved, clearlydefined
 npm/npmjs/@react-hook/latest/1.0.3, MIT, approved, clearlydefined
-npm/npmjs/@reduxjs/toolkit/2.2.3, MIT AND (BSD-2-Clause AND ISC AND MIT) AND Apache-2.0, approved, #14170
-npm/npmjs/@restart/hooks/0.4.16, MIT, approved, #7049
-npm/npmjs/@restart/ui/1.6.8, MIT, approved, clearlydefined
+npm/npmjs/@reduxjs/toolkit/2.2.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND Apache-2.0, approved, #14170
+npm/npmjs/@remix-run/router/1.15.3, MIT, approved, clearlydefined
 npm/npmjs/@rollup/pluginutils/5.1.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-android-arm-eabi/4.14.3, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-android-arm64/4.14.3, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-darwin-arm64/4.14.3, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-darwin-x64/4.14.3, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-arm-gnueabihf/4.14.3, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-arm-musleabihf/4.14.3, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-arm64-gnu/4.14.3, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-arm64-musl/4.14.3, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-powerpc64le-gnu/4.14.3, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-riscv64-gnu/4.14.3, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-s390x-gnu/4.14.3, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-x64-gnu/4.14.3, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-x64-musl/4.14.3, MIT AND (ISC AND MIT), approved, #14391
-npm/npmjs/@rollup/rollup-win32-arm64-msvc/4.14.3, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-win32-ia32-msvc/4.14.3, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-win32-x64-msvc/4.14.3, MIT AND (ISC AND MIT), approved, #14392
+npm/npmjs/@rollup/rollup-android-arm-eabi/4.13.0, MIT, approved, clearlydefined
+npm/npmjs/@rollup/rollup-android-arm64/4.13.0, MIT, approved, clearlydefined
+npm/npmjs/@rollup/rollup-darwin-arm64/4.13.0, MIT, approved, clearlydefined
+npm/npmjs/@rollup/rollup-darwin-x64/4.13.0, MIT, approved, clearlydefined
+npm/npmjs/@rollup/rollup-linux-arm-gnueabihf/4.13.0, MIT, approved, clearlydefined
+npm/npmjs/@rollup/rollup-linux-arm64-gnu/4.13.0, MIT, approved, clearlydefined
+npm/npmjs/@rollup/rollup-linux-arm64-musl/4.13.0, MIT, approved, clearlydefined
+npm/npmjs/@rollup/rollup-linux-riscv64-gnu/4.13.0, MIT, approved, clearlydefined
+npm/npmjs/@rollup/rollup-linux-x64-gnu/4.13.0, MIT, approved, clearlydefined
+npm/npmjs/@rollup/rollup-linux-x64-musl/4.13.0, MIT, approved, clearlydefined
+npm/npmjs/@rollup/rollup-win32-arm64-msvc/4.13.0, MIT, approved, clearlydefined
+npm/npmjs/@rollup/rollup-win32-ia32-msvc/4.13.0, MIT, approved, clearlydefined
+npm/npmjs/@rollup/rollup-win32-x64-msvc/4.13.0, MIT, approved, clearlydefined
 npm/npmjs/@sinclair/typebox/0.27.8, MIT, approved, clearlydefined
 npm/npmjs/@sinonjs/commons/3.0.1, BSD-3-Clause, approved, #12905
 npm/npmjs/@sinonjs/fake-timers/10.3.0, BSD-3-Clause, approved, #9214
@@ -741,13 +725,12 @@ npm/npmjs/@svgr/babel-preset/8.1.0, MIT, approved, clearlydefined
 npm/npmjs/@svgr/core/8.1.0, MIT, approved, clearlydefined
 npm/npmjs/@svgr/hast-util-to-babel-ast/8.0.0, MIT, approved, clearlydefined
 npm/npmjs/@svgr/plugin-jsx/8.1.0, MIT, approved, clearlydefined
-npm/npmjs/@swc/helpers/0.5.10, Apache-2.0, approved, #10985
 npm/npmjs/@testing-library/dom/9.3.4, MIT AND (MIT AND WTFPL), approved, #9038
 npm/npmjs/@testing-library/jest-dom/6.4.2, MIT, approved, clearlydefined
-npm/npmjs/@testing-library/react/14.3.1, MIT, approved, #14385
+npm/npmjs/@testing-library/react/14.2.2, MIT, approved, #13316
 npm/npmjs/@testing-library/user-event/14.5.2, MIT, approved, clearlydefined
 npm/npmjs/@tootallnate/once/2.0.0, MIT, approved, clearlydefined
-npm/npmjs/@tsconfig/node10/1.0.11, MIT, approved, clearlydefined
+npm/npmjs/@tsconfig/node10/1.0.9, MIT, approved, clearlydefined
 npm/npmjs/@tsconfig/node12/1.0.11, MIT, approved, clearlydefined
 npm/npmjs/@tsconfig/node14/1.0.3, MIT, approved, clearlydefined
 npm/npmjs/@tsconfig/node16/1.0.4, MIT, approved, clearlydefined
@@ -769,36 +752,35 @@ npm/npmjs/@types/json5/0.0.29, MIT, approved, clearlydefined
 npm/npmjs/@types/lodash.debounce/4.0.9, MIT, approved, clearlydefined
 npm/npmjs/@types/lodash.uniq/4.5.9, MIT, approved, #13930
 npm/npmjs/@types/lodash/4.17.0, MIT, approved, clearlydefined
-npm/npmjs/@types/node/20.12.7, MIT, approved, clearlydefined
+npm/npmjs/@types/node/20.11.30, MIT, approved, #13826
 npm/npmjs/@types/papaparse/5.3.14, MIT, approved, #10964
 npm/npmjs/@types/parse-json/4.0.2, MIT, approved, clearlydefined
-npm/npmjs/@types/prop-types/15.7.12, MIT, approved, clearlydefined
-npm/npmjs/@types/qs/6.9.15, MIT, approved, #14071
-npm/npmjs/@types/react-dom/18.2.25, MIT, approved, #8256
+npm/npmjs/@types/prop-types/15.7.11, MIT, approved, clearlydefined
+npm/npmjs/@types/qs/6.9.13, MIT, approved, #13931
+npm/npmjs/@types/react-dom/18.2.22, MIT, approved, #8256
 npm/npmjs/@types/react-redux/7.1.33, MIT, approved, #10970
 npm/npmjs/@types/react-slick/0.23.13, MIT, approved, #11666
 npm/npmjs/@types/react-transition-group/4.4.10, MIT, approved, #8416
-npm/npmjs/@types/react/18.2.79, MIT, approved, #8234
-npm/npmjs/@types/redux-actions/2.6.5, MIT, approved, #10989
+npm/npmjs/@types/react/18.2.71, MIT, approved, #8234
+npm/npmjs/@types/scheduler/0.16.8, MIT, approved, #7582
 npm/npmjs/@types/semver/7.5.8, MIT, approved, #10842
 npm/npmjs/@types/stack-utils/2.0.3, MIT, approved, clearlydefined
 npm/npmjs/@types/tough-cookie/4.0.5, MIT, approved, #10798
 npm/npmjs/@types/use-sync-external-store/0.0.3, MIT, approved, clearlydefined
-npm/npmjs/@types/warning/3.0.3, MIT, approved, #10988
 npm/npmjs/@types/yargs-parser/21.0.3, MIT, approved, clearlydefined
 npm/npmjs/@types/yargs/17.0.32, MIT, approved, #7054
-npm/npmjs/@typescript-eslint/eslint-plugin/7.7.0, BSD-2-Clause AND MIT AND (BSD-2-Clause AND ISC AND MIT), approved, #14387
+npm/npmjs/@typescript-eslint/eslint-plugin/7.3.1, BSD-2-Clause AND (BSD-2-Clause AND ISC AND MIT) AND MIT, approved, #13933
 npm/npmjs/@typescript-eslint/parser/6.21.0, BSD-2-Clause, approved, clearlydefined
-npm/npmjs/@typescript-eslint/parser/7.7.0, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/@typescript-eslint/parser/7.3.1, BSD-2-Clause AND (BSD-2-Clause AND ISC AND MIT) AND MIT, approved, #13938
 npm/npmjs/@typescript-eslint/scope-manager/6.21.0, MIT, approved, clearlydefined
-npm/npmjs/@typescript-eslint/scope-manager/7.7.0, MIT, approved, clearlydefined
-npm/npmjs/@typescript-eslint/type-utils/7.7.0, MIT, approved, clearlydefined
+npm/npmjs/@typescript-eslint/scope-manager/7.3.1, BSD-2-Clause AND (BSD-2-Clause AND ISC AND MIT) AND MIT, approved, #13937
+npm/npmjs/@typescript-eslint/type-utils/7.3.1, BSD-2-Clause AND (BSD-2-Clause AND ISC AND MIT) AND MIT, approved, #13936
 npm/npmjs/@typescript-eslint/types/6.21.0, MIT, approved, clearlydefined
-npm/npmjs/@typescript-eslint/types/7.7.0, MIT, approved, clearlydefined
+npm/npmjs/@typescript-eslint/types/7.3.1, BSD-2-Clause AND (BSD-2-Clause AND ISC AND MIT) AND MIT, approved, #13934
 npm/npmjs/@typescript-eslint/typescript-estree/6.21.0, BSD-2-Clause AND (BSD-2-Clause AND ISC AND MIT) AND MIT, approved, #13165
-npm/npmjs/@typescript-eslint/typescript-estree/7.7.0, BSD-2-Clause AND MIT AND (BSD-2-Clause AND ISC AND MIT), approved, #14390
-npm/npmjs/@typescript-eslint/utils/7.7.0, BSD-2-Clause AND MIT AND (BSD-2-Clause AND ISC AND MIT), approved, #14389
+npm/npmjs/@typescript-eslint/typescript-estree/7.3.1, BSD-2-Clause AND (BSD-2-Clause AND ISC AND MIT) AND MIT, approved, #13935
+npm/npmjs/@typescript-eslint/utils/7.3.1, BSD-2-Clause AND (BSD-2-Clause AND ISC AND MIT) AND MIT, approved, #13940
 npm/npmjs/@typescript-eslint/visitor-keys/6.21.0, MIT, approved, clearlydefined
-npm/npmjs/@typescript-eslint/visitor-keys/7.7.0, MIT, approved, clearlydefined
+npm/npmjs/@typescript-eslint/visitor-keys/7.3.1, BSD-2-Clause AND (BSD-2-Clause AND ISC AND MIT) AND MIT, approved, #13939
 npm/npmjs/@ungap/structured-clone/1.2.0, ISC, approved, clearlydefined
 npm/npmjs/@vitejs/plugin-react/4.2.1, MIT, approved, clearlydefined

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "pretty": "prettier --write \"./src/**/*.{ts,tsx,js,jsx,json,css,sass,scss,xml,md}\"",
     "lint": "eslint \"./src/**/*.{ts,tsx,js,jsx}\" --report-unused-disable-directives --max-warnings 0",
     "start": "vite --host --port 3002",
-    "build": "yarn build:copy-legal-info && tsc && vite build && mkdir registration && mv build/* registration && mv registration build/",
+    "build": "yarn build:copy-legal-info && tsc && vite build",
     "build:legal-notice": "bash scripts/legal-notice.sh",
     "build:copy-legal-info": "cp LICENSE NOTICE.md DEPENDENCIES SECURITY.md public/",
     "test": "jest",


### PR DESCRIPTION
## Description

Change output folder to build/ instead of build/registration/

## Why

The ingress controller manages the context root on Kubernetes.

## Issue

#123 

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally