### PR TITLE
fix(defaults): revert defaults set to empty string

### DIFF
--- a/src/components/cax-companyData.tsx
+++ b/src/components/cax-companyData.tsx
@@ -73,7 +73,7 @@ export const CompanyDataCax = () => {
   const { data: status } = useFetchApplicationsQuery()
 
   const obj = status?.[status.length - 1] //.find(o => o['applicationStatus'] === CREATED);
-  const applicationId = obj?.applicationId ?? ''
+  const applicationId = obj?.applicationId
 
   const [bpn, setBpn] = useState('')
   const [bpnErrorMsg, setBpnErrorMessage] = useState('')
@@ -156,14 +156,14 @@ export const CompanyDataCax = () => {
   }, [identifierType, identifierNumber, country])
 
   useEffect(() => {
-    setBpn(companyDetails?.bpn ?? '')
-    setLegalEntity(companyDetails?.name ?? '')
-    setRegisteredName(companyDetails?.name ?? '')
-    setStreetHouseNumber(companyDetails?.streetName ?? '')
-    setRegion(companyDetails?.region ?? '')
-    setPostalCode(companyDetails?.zipCode ?? '')
-    setCity(companyDetails?.city ?? '')
-    setCountry(companyDetails?.countryAlpha2Code ?? '')
+    setBpn(companyDetails?.bpn)
+    setLegalEntity(companyDetails?.name)
+    setRegisteredName(companyDetails?.name)
+    setStreetHouseNumber(companyDetails?.streetName)
+    setRegion(companyDetails?.region)
+    setPostalCode(companyDetails?.zipCode)
+    setCity(companyDetails?.city)
+    setCountry(companyDetails?.countryAlpha2Code)
     setUniqueIds(companyDetails?.uniqueIds)
     setIdentifierNumber(companyDetails?.uniqueIds?.[0]?.value)
     setIdentifierType(companyDetails?.uniqueIds?.[0]?.type)
@@ -377,8 +377,8 @@ export const CompanyDataCax = () => {
     companyData.countryAlpha2Code = country
     companyData.uniqueIds = [
       {
-        type: identifierType ?? '',
-        value: identifierNumber ?? '',
+        type: identifierType,
+        value: identifierNumber,
       },
     ]
     //addCompanyData(companyData)
@@ -568,12 +568,11 @@ export const CompanyDataCax = () => {
                 <Autocomplete
                   id="selectList"
                   options={countryArr}
-                  defaultValue={defaultSelectedCountry ?? ''}
+                  defaultValue={defaultSelectedCountry}
                   renderInput={(params) => (
                     <TextField variant="standard" {...params} />
                   )}
                   onChange={(_e, values) => {
-                    // @ts-expect-error keep for compatibility
                     validateCountry(values?.id)
                   }}
                   sx={{

--- a/src/components/cax-companyRole.tsx
+++ b/src/components/cax-companyRole.tsx
@@ -58,7 +58,7 @@ export const CompanyRoleCax = () => {
   const { data: allConsentData, error: allConsentError } =
     useFetchAgreementDataQuery()
   const { data: consentData, error: consentError } =
-    useFetchAgreementConsentsQuery(applicationId ?? '')
+    useFetchAgreementConsentsQuery(applicationId)
   const [updateAgreementConsents] = useUpdateAgreementConsentsMutation()
 
   useEffect(() => {
@@ -95,7 +95,7 @@ export const CompanyRoleCax = () => {
       )
 
       const updatedAgreementIds = allConsentData?.companyRoles[
-        companyRoleIndex ?? ''
+        companyRoleIndex
       ].agreementIds.reduce((prev, next) => {
         return { ...prev, [next]: false }
       }, {})
@@ -127,7 +127,7 @@ export const CompanyRoleCax = () => {
         .then(async (res) => {
           const fileType = res.headers.get('content-type')
           const file = await res.blob()
-          download(file, fileType ?? '', documentName)
+          download(file, fileType, documentName)
         })
         .catch((error) => {
           console.log(error)
@@ -215,7 +215,7 @@ export const CompanyRoleCax = () => {
       agreements,
     }
 
-    await updateAgreementConsents({ applicationId: applicationId ?? '', data })
+    await updateAgreementConsents({ applicationId, data })
       .unwrap()
       .then(() => {
         dispatch(addCurrentStep(currentActiveStep + 1))

--- a/src/components/cax-responsibilities.tsx
+++ b/src/components/cax-responsibilities.tsx
@@ -66,7 +66,7 @@ export const ResponsibilitiesCax = () => {
   const { data: status } = useFetchApplicationsQuery()
 
   const obj = status?.[status.length - 1] //.find(o => o['applicationStatus'] === CREATED);
-  const applicationId = obj?.applicationId ?? ''
+  const applicationId = obj?.applicationId
 
   const [updateInviteNewUser] = useUpdateInviteNewUserMutation()
   const { data: rolesComposite, error: rolesError } =
@@ -201,7 +201,7 @@ export const ResponsibilitiesCax = () => {
               <input
                 type="text"
                 name="email"
-                value={email ?? ''}
+                value={email}
                 onChange={(e) => validateEmailOnChange(e.target.value)}
               />
               <AiOutlineExclamationCircle className="error-icon" />
@@ -212,7 +212,7 @@ export const ResponsibilitiesCax = () => {
           <Row className="mx-auto col-9">
             <div className="form-data">
               <label>{t('Responsibility.role')}</label>
-              <select value={role ?? ''} onChange={(e) => onRoleChange(e)}>
+              <select value={role} onChange={(e) => onRoleChange(e)}>
                 {availableUserRoles &&
                   availableUserRoles.map((role, index) => (
                     <option key={index} value={role}>
@@ -228,7 +228,7 @@ export const ResponsibilitiesCax = () => {
               <label>{t('Responsibility.note')}</label>
               <textarea
                 name="message"
-                value={message ?? ''}
+                value={message}
                 onChange={(e) => validatePersonalNoteOnChange(e.target.value)}
               />
               <div className="error-message">{appError.personalNote}</div>

--- a/src/components/dragdrop.tsx
+++ b/src/components/dragdrop.tsx
@@ -78,7 +78,7 @@ export const DragDrop = () => {
 
   const { data: status } = useFetchApplicationsQuery()
   const obj = status?.[status.length - 1]
-  const applicationId = obj?.applicationId ?? ''
+  const applicationId = obj?.applicationId
 
   const [fileError, setFileError] = useState('')
   const [deleteDocResponse, setDeleteDocResponse] = useState({
@@ -231,7 +231,7 @@ export const DragDrop = () => {
                   {document.documentName}
                 </div>
                 <div className="dropzone-overview-file-status">
-                  {`${getStatusText(document.status ?? '')} ${
+                  {`${getStatusText(document.status)} ${
                     document.progress && document?.progress !== 100
                       ? document?.progress
                       : ''
@@ -241,7 +241,7 @@ export const DragDrop = () => {
                   <div
                     role="progressbar"
                     className={`progress-bar bg-${getClassNameByStatus(
-                      document.status ?? ''
+                      document.status
                     )}`}
                     style={{
                       width: `${document?.progress}%`,

--- a/src/components/footerButton.tsx
+++ b/src/components/footerButton.tsx
@@ -62,7 +62,7 @@ export const FooterButton = ({
             }
             handleClick={handleNextClick}
             showTooltip={tooltip ? true : false}
-            tooltipText={tooltip ?? ''}
+            tooltipText={tooltip}
             disabled={disabled}
             loading={loading}
           />

--- a/src/components/footerHeadline.tsx
+++ b/src/components/footerHeadline.tsx
@@ -29,7 +29,7 @@ export const FooterHeadline = ({ helpUrl }: { helpUrl?: string }) => {
       <a
         href={window.location.pathname.replace(
           window.location.pathname,
-          helpUrl ?? ''
+          helpUrl
         )}
         target="_blank"
         rel="noreferrer"

--- a/src/components/verifyRegistration.tsx
+++ b/src/components/verifyRegistration.tsx
@@ -50,7 +50,7 @@ export const VerifyRegistration = () => {
   const { data: status } = useFetchApplicationsQuery()
 
   const obj = status?.[status.length - 1]
-  const applicationId = obj?.applicationId ?? ''
+  const applicationId = obj?.applicationId
 
   const { data: registrationData, error: dataError } =
     useFetchRegistrationDataQuery(applicationId)
@@ -87,7 +87,7 @@ export const VerifyRegistration = () => {
     return null
   }
 
-  const hasRoles = () => (registrationData?.companyRoles.length ?? 0) > 0
+  const hasRoles = () => registrationData?.companyRoles.length > 0
 
   const hasDocuments = () => documents && documents.length > 0
 


### PR DESCRIPTION
## Description

Reverted defaults from empty string to undefined 

## Why

In the process of the framework upgrade some default values have been set to the empty string from before undefined. This caused issues with some api endpoints.

## Issue

#123
https://github.com/eclipse-tractusx/portal-backend/issues/639

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally