### PR TITLE
fix(consent osp): redirect to portal page instead of overlay

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -531,7 +531,7 @@ npm/npmjs/-/typed-array-buffer/1.0.2, MIT, approved, #9658
 npm/npmjs/-/typed-array-byte-length/1.0.1, MIT, approved, #9659
 npm/npmjs/-/typed-array-byte-offset/1.0.2, MIT, approved, #9407
 npm/npmjs/-/typed-array-length/1.0.6, MIT, approved, #6246
-npm/npmjs/-/typescript/5.4.5, Apache-2.0 AND MIT AND CC-BY-4.0 AND Unicode-DFS-2016 AND W3C-20150513, approved, #13647
+npm/npmjs/-/typescript/5.4.5, Apache-2.0 AND (CC-BY-4.0 AND LicenseRef-Unicode AND MIT AND W3C-20150513) AND BSD-3-Clause AND ODbL-1.0 AND MIT, approved, #15244
 npm/npmjs/-/unbox-primitive/1.0.2, MIT, approved, clearlydefined
 npm/npmjs/-/uncontrollable/7.2.1, MIT AND BSD-3-Clause, approved, #3025
 npm/npmjs/-/uncontrollable/8.0.4, MIT, approved, clearlydefined

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -289,6 +289,6 @@ export function handleStatusRedirect(
     location.href = '/'
   else if (Object.values(ApplicationStatus).includes(status)) {
     if (applicationType === ApplicationType.INTERNAL) history.push('/landing')
-    else location.href = '/?overlay=consent_osp'
+    else location.href = '/consent_osp'
   } else history.push('/landing')
 }


### PR DESCRIPTION
## Description

For consent OSP redirect to portal page instead of overlay

## Why

In the portal the dialog has been converted from an overlay to a page. The redirect here was still pointing to the old url

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/907

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally