### PR TITLE
fix(identifiers): allow for shorter and longer german crn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## unreleased
 
+### Change
+- adjusted german and worldwide CRN REGEX to allow court names [#250](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/250)
+
 ### Bugfix
 
 - country value is not updating if user moves back and forth between steps [#232](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/232)

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -772,7 +772,7 @@ npm/npmjs/@types/lodash/4.17.7, MIT, approved, clearlydefined
 npm/npmjs/@types/node/20.12.14, MIT, approved, clearlydefined
 npm/npmjs/@types/papaparse/5.3.14, MIT, approved, #10964
 npm/npmjs/@types/parse-json/4.0.2, MIT, approved, clearlydefined
-npm/npmjs/@types/prop-types/15.7.12, MIT, approved, clearlydefined
+npm/npmjs/@types/prop-types/15.7.12, MIT, approved, #16176
 npm/npmjs/@types/qs/6.9.15, MIT, approved, #14071
 npm/npmjs/@types/react-dom/18.2.25, MIT, approved, #8256
 npm/npmjs/@types/react-redux/7.1.33, MIT, approved, #10970

--- a/src/locales/de/translations.json
+++ b/src/locales/de/translations.json
@@ -76,7 +76,7 @@
     "IN_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with hyphen with 4 to 21 digits.",
     "IN_VAT_ID": "Please enter a valid number. Hint: Alphanumeric with hyphen with 5 to 15 digits.",
     "IN_LEI_CODE": "Please enter a valid number. Hint: Alphanumeric with exact 20 digits.",
-    "DE_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with hyphen and space with 4 to 21 character.",
+    "DE_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with hyphen and space.",
     "DE_VAT_ID": "Please enter a valid number. Hint: Starting with DE and followed by 9 digit numbers",
     "DE_LEI_CODE": "Please enter a valid number. Hint: Alphanumeric with exact 20 digits.",
     "FR_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with space with 14 to 17 digits.",

--- a/src/locales/de/translations.json
+++ b/src/locales/de/translations.json
@@ -76,7 +76,7 @@
     "IN_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with hyphen with 4 to 21 digits.",
     "IN_VAT_ID": "Please enter a valid number. Hint: Alphanumeric with hyphen with 5 to 15 digits.",
     "IN_LEI_CODE": "Please enter a valid number. Hint: Alphanumeric with exact 20 digits.",
-    "DE_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with hyphen and space with exact 9 digits.",
+    "DE_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with hyphen and space with 4 to 21 character.",
     "DE_VAT_ID": "Please enter a valid number. Hint: Starting with DE and followed by 9 digit numbers",
     "DE_LEI_CODE": "Please enter a valid number. Hint: Alphanumeric with exact 20 digits.",
     "FR_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with space with 14 to 17 digits.",

--- a/src/locales/en/translations.json
+++ b/src/locales/en/translations.json
@@ -76,7 +76,7 @@
     "IN_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with hyphen with 4 to 21 digits.",
     "IN_VAT_ID": "Please enter a valid number. Hint: Alphanumeric with hyphen with 5 to 15 digits.",
     "IN_LEI_CODE": "Please enter a valid number. Hint: Alphanumeric with exact 20 digits.",
-    "DE_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with hyphen and space with 4 to 21 character.",
+    "DE_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with hyphen and space.",
     "DE_VAT_ID": "Please enter a valid number. Hint: Starting with DE and followed by 9 digit numbers",
     "DE_LEI_CODE": "Please enter a valid number. Hint: Alphanumeric with exact 20 digits.",
     "FR_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with space with 14 to 17 digits.",

--- a/src/locales/en/translations.json
+++ b/src/locales/en/translations.json
@@ -76,7 +76,7 @@
     "IN_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with hyphen with 4 to 21 digits.",
     "IN_VAT_ID": "Please enter a valid number. Hint: Alphanumeric with hyphen with 5 to 15 digits.",
     "IN_LEI_CODE": "Please enter a valid number. Hint: Alphanumeric with exact 20 digits.",
-    "DE_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with hyphen and space with exact 9 digits.",
+    "DE_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with hyphen and space with 4 to 21 character.",
     "DE_VAT_ID": "Please enter a valid number. Hint: Starting with DE and followed by 9 digit numbers",
     "DE_LEI_CODE": "Please enter a valid number. Hint: Alphanumeric with exact 20 digits.",
     "FR_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with space with 14 to 17 digits.",

--- a/src/types/Patterns.ts
+++ b/src/types/Patterns.ts
@@ -39,8 +39,8 @@ const VAT_ID = {
   MX: /^[a-zA-Z\d-&]{12,13}$/,
 }
 const COMMERCIAL_REG_NUMBER = {
-  Worldwide: /^(?!.*\s$)([A-Za-z0-9](\.|\s|-)?){4,21}$/, // generic pattern
-  DE: /^(?!.*\s$)([A-Za-z0-9](\s|-)?){4,21}$/,
+  Worldwide: /^(?!.*\s$)([A-Za-zÀ-ÿ0-9.()](\.|\s|-)?){4,50}$/, // generic pattern
+  DE: /^(?!.*\s$)([A-Za-zÀ-ÿ0-9.()](\s|-)?){4,50}$/,
   FR: /^(?!.*\s$)([A-Za-z0-9]\s?){14,17}$/,
 }
 

--- a/src/types/Patterns.ts
+++ b/src/types/Patterns.ts
@@ -40,7 +40,7 @@ const VAT_ID = {
 }
 const COMMERCIAL_REG_NUMBER = {
   Worldwide: /^(?!.*\s$)([A-Za-z0-9](\.|\s|-)?){4,21}$/, // generic pattern
-  DE: /^(?!.*\s$)([A-Za-z0-9](\s|-)?){9}$/,
+  DE: /^(?!.*\s$)([A-Za-z0-9](\s|-)?){4,21}$/,
   FR: /^(?!.*\s$)([A-Za-z0-9]\s?){14,17}$/,
 }
 

--- a/src/types/testdata/crn.ts
+++ b/src/types/testdata/crn.ts
@@ -24,14 +24,15 @@ export const CRN_TEST_DATA = {
       '987654321',
       '000000000',
       // Valid records found at https://www.unternehmensregister.de/ureg/ (German Handelsregister)
-      // 'HRB 209459',
-      // 'HRB 86891',
-      // 'HRA 5778',
-      // 'HRB 112676',
-      // 'HRB 92821',
-      // 'VR 9277',
-      // 'HRB 42', // Südzucker AG
-      // 'HRA 3679 FL'
+      'HRB 209459',
+      'HRB 86891',
+      'HRA 5778',
+      'HRB 112676',
+      'HRB 92821',
+      'VR 9277',
+      'HRB 42', // Südzucker AG
+      'HRA 3679 FL',
+      'HRB 209459 B',
     ],
     invalid: [
       '', // empty
@@ -39,9 +40,6 @@ export const CRN_TEST_DATA = {
       '123456789 ', // trailing whitespace
       ' 123456789', // leading whitespace
       '12345  6789', // invalid character (double whitespace)
-      // 'HRB 209459 ', // trailing whitespace
-      // ' HRB 209459', // leading whitespace
-      // 'HRB  2094590', // invalid character (double whitespace)
     ],
   },
   FR: {
@@ -56,6 +54,7 @@ export const CRN_TEST_DATA = {
       ' ', // whitespace
       '83449681200035 ', // trailing whitespace
       ' 83449681200035', // leading whitespace
+      '8344968  1200035', // invalid character (double whitespace)
     ],
   },
   MX: {
@@ -69,6 +68,7 @@ export const CRN_TEST_DATA = {
       ' ', // whitespace
       'ABC20010101AAA ', // trailing space
       ' ABC20010101AAA', // leading space
+      'ABC200  10101AAA', // invalid character (double whitespace)
     ],
   },
   IN: {
@@ -82,6 +82,7 @@ export const CRN_TEST_DATA = {
       ' ', // whitespace
       '27AASCS2460H1Z0 ', // trailing space
       ' 27AASCS2460H1Z0', // leading space
+      '27AASCS  2460H1Z0', // invalid character (double whitespace)
     ],
   },
   Worldwide: {
@@ -99,6 +100,7 @@ export const CRN_TEST_DATA = {
       ' ', // whitespace
       ' DE123456789', // leading space
       'DE123456789 ', // trailing space
+      'DE  123456789', // invalid character (double whitespace)
     ],
   },
 }

--- a/src/types/testdata/crn.ts
+++ b/src/types/testdata/crn.ts
@@ -100,8 +100,6 @@ export const CRN_TEST_DATA = {
       '37AAACP2678Q1ZP',
       'CHE-123.456.788', // Swiss
       'CHE-116.281.710', // Swiss
-      'München HRB 123456', // German
-      'Frankfurt am Main HRB 134317', // German
     ],
     invalid: [
       '', // empty

--- a/src/types/testdata/crn.ts
+++ b/src/types/testdata/crn.ts
@@ -33,6 +33,12 @@ export const CRN_TEST_DATA = {
       'HRB 42', // Südzucker AG
       'HRA 3679 FL',
       'HRB 209459 B',
+      'München HRB 175450',
+      'Frankfurt am Main HRB 134317',
+      'Oldenburg (Oldenburg) VR 1706',
+      'Ludwigshafen a.Rhein (Ludwigshafen) VR 60423',
+      'Weiden i. d. OPf. HRB 4339',
+      'Berlin-Charlottenburg HRB 98814',
     ],
     invalid: [
       '', // empty
@@ -94,6 +100,8 @@ export const CRN_TEST_DATA = {
       '37AAACP2678Q1ZP',
       'CHE-123.456.788', // Swiss
       'CHE-116.281.710', // Swiss
+      'München HRB 123456', // German
+      'Frankfurt am Main HRB 134317', // German
     ],
     invalid: [
       '', // empty


### PR DESCRIPTION
## Description

Update Commercial Registration Number pattern for germany:
- Min length to 4
- Max length to 50
- Special characters äüö
- Round braces ()
- dot .

Same extension for worldwide.

Added tests cases for valid german company registration numbers.

Updated error messages.

## Why

Some examples of german company registration numbers did not work with old pattern. See 'HRB 42' or 'HRB 209459 B'. Min/max length alligned with worldwide pattern.

German CRN also requires the court name to be regarded unique. This means that much longer identifiers and some additional special characters need to be allowed.

## Issue

Refs: #190

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
