### PR TITLE
fix: update the roles state when user navigate between the steps

### DIFF
--- a/src/components/cax-companyRole.tsx
+++ b/src/components/cax-companyRole.tsx
@@ -57,9 +57,16 @@ export const CompanyRoleCax = () => {
 
   const { data: allConsentData, error: allConsentError } =
     useFetchAgreementDataQuery()
-  const { data: consentData, error: consentError } =
-    useFetchAgreementConsentsQuery(applicationId)
+  const {
+    data: consentData,
+    error: consentError,
+    refetch,
+  } = useFetchAgreementConsentsQuery(applicationId)
   const [updateAgreementConsents] = useUpdateAgreementConsentsMutation()
+
+  useEffect(() => {
+    refetch()
+  }, [companyRoleChecked])
 
   useEffect(() => {
     updateSelectedRolesAndAgreement()

--- a/src/components/verifyRegistration.tsx
+++ b/src/components/verifyRegistration.tsx
@@ -24,7 +24,7 @@ import { useTranslation } from 'react-i18next'
 import { FooterButton } from './footerButton'
 import { useDispatch, useSelector } from 'react-redux'
 import { useHistory } from 'react-router-dom'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useFetchApplicationsQuery } from '../state/features/application/applicationApiSlice'
 import { useFetchDocumentsQuery } from '../state/features/applicationDocuments/applicationDocumentsApiSlice'
 import {
@@ -52,12 +52,19 @@ export const VerifyRegistration = () => {
   const obj = status?.[status.length - 1]
   const applicationId = obj?.applicationId
 
-  const { data: registrationData, error: dataError } =
-    useFetchRegistrationDataQuery(applicationId)
+  const {
+    data: registrationData,
+    error: dataError,
+    refetch,
+  } = useFetchRegistrationDataQuery(applicationId)
   const { data: documents, error: documentsError } =
     useFetchDocumentsQuery(applicationId)
   const [updateRegistration] = useUpdateRegistrationMutation()
-
+  
+  useEffect(() => {
+    refetch()
+  }, [])
+  
   const backClick = () => {
     dispatch(addCurrentStep(currentActiveStep - 1))
   }


### PR DESCRIPTION
## Description

Roles are not updated during the registration process in role selection and data verification steps if the user navigates between steps.

## Why

- When completing the registration, on third steps if we select any roles and navigate till last step, where we have selected roles section.
- Now if user navigate back to the third step, made some changes.
- Again navigate to last step, here these roles are not getting updated.
- Navigate back to third step, you will see the old data instead of latest roles.
- This issue is addressed in this MR

## Issue

Link to Github issue : https://github.com/eclipse-tractusx/portal-frontend-registration/issues/212

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally