### PR TITLE
feat(legal entity): extended legal entity length

### DIFF
--- a/src/types/Patterns.test.ts
+++ b/src/types/Patterns.test.ts
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { isPattern, Patterns } from './Patterns'
+import { isBPN, isCity, isLegalEntity, isPattern, isStreet, Patterns } from './Patterns'
 import { BPN_TEST_DATA } from './testdata/bpn'
 import { CITY_TEST_DATA } from './testdata/city'
 import { STREET_TEST_DATA } from './testdata/street'
@@ -27,6 +27,7 @@ import { EORI_TEST_DATA } from './testdata/eori'
 import { LEI_TEST_DATA } from './testdata/lei'
 import { VIES_TEST_DATA } from './testdata/vies'
 import { CRN_TEST_DATA } from './testdata/crn'
+import { LEGAL_ENTITY_DATA } from './testdata/legalentity'
 
 const validate = (data, check) => {
   data.valid.forEach((expr) => {
@@ -48,16 +49,23 @@ const validateIdentifierPattern = (pattern: string, testData: any) => {
 
 describe('Input Pattern Tests', () => {
   it('validates BPN pattern', () => {
-    validate(BPN_TEST_DATA.BPN, (expr: string) => isPattern(Patterns.BPN, expr))
+    validate(BPN_TEST_DATA.BPN, (expr: string) =>
+      isBPN(expr)
+    )
   })
   it('validates City pattern', () => {
     validate(CITY_TEST_DATA.CITY, (expr: string) =>
-      isPattern(Patterns.CITY, expr)
+      isCity(expr)
     )
   })
   it('validates Street pattern', () => {
     validate(STREET_TEST_DATA.STREET, (expr: string) =>
-      isPattern(Patterns.STREET, expr)
+      isStreet(expr)
+    )
+  })
+  it('validates legalEntityPattern pattern', () => {
+    validate(LEGAL_ENTITY_DATA.LEGAL_ENTITY, (expr: string) =>
+      isLegalEntity(expr)
     )
   })
 

--- a/src/types/Patterns.ts
+++ b/src/types/Patterns.ts
@@ -50,8 +50,12 @@ export const Patterns = {
   CITY: /^[A-ZÀ-ÿ0-9Śął](([ .'-]|\. )?[A-Za-zÀ-ÿ0-9Śął]{1,40}){1,10}$/,
   STREET:
     /^(?!.*\s$)([a-zA-Z0-9À-ÿšŚął]{1,40}( ?[.,'/-] ?| )?){1,10}[a-zA-Z0-9À-ÿšŚął.]$/,
+  // legalEntityPattern
+  // \w covers A-Za-z0-9 and _
+  // \s whitespace
+  // \x22 double quote
   legalEntityPattern:
-    /^(?!.*\s$)([\wÀ-ÿ\d#'£$€¥¢@&%()*+,\-_./:;=<>!?^[\]\\]\s?){1,160}$/,
+    /^(?!.*\s$)([\wÀ-ÿ£$€¥¢@%*+\-/\\,.:;=<>!?&^#'\x22()[\]]\s?){1,160}$/,
   registeredNamePattern:
     /^(?!.*\s$)[a-zA-ZÀ-ÿŚął\d][a-zA-ZÀ-ÿŚął\d\s!#'$@&%()*+,\-_./:;=<>?[\]\\^]{2,60}$/,
   regionPattern: /^(?!.*\s$)([a-zA-Z0-9À-ÿŚął,"()'-]\s?)*$/,

--- a/src/types/Patterns.ts
+++ b/src/types/Patterns.ts
@@ -51,7 +51,7 @@ export const Patterns = {
   STREET:
     /^(?!.*\s$)([a-zA-Z0-9À-ÿšŚął]{1,40}( ?[.,'/-] ?| )?){1,10}[a-zA-Z0-9À-ÿšŚął.]$/,
   legalEntityPattern:
-    /^(?!.*\s$)[a-zA-ZÀ-ÿ\d][a-zA-ZÀ-ÿ\d\s!#'$@&%()*+,\-_./:;=<>?[\]\\^]{2,50}$/,
+    /^(?!.*\s$)([\wÀ-ÿ\d#'£$€¥¢@&%()*+,\-_./:;=<>!?^[\]\\]\s?){1,160}$/,
   registeredNamePattern:
     /^(?!.*\s$)[a-zA-ZÀ-ÿŚął\d][a-zA-ZÀ-ÿŚął\d\s!#'$@&%()*+,\-_./:;=<>?[\]\\^]{2,60}$/,
   regionPattern: /^(?!.*\s$)([a-zA-Z0-9À-ÿŚął,"()'-]\s?)*$/,
@@ -98,6 +98,14 @@ export const Patterns = {
 export const isBPN = (expr: string) => Patterns.BPN.test(expr)
 export const isCity = (expr: string) => Patterns.CITY.test(expr)
 export const isStreet = (expr: string) => Patterns.STREET.test(expr)
+export const isLegalEntity = (expr: string) =>
+  Patterns.legalEntityPattern.test(expr)
+export const isRegisteredName = (expr: string) =>
+  Patterns.registeredNamePattern.test(expr)
+export const isRegion = (expr: string) => Patterns.regionPattern.test(expr)
+export const isPostalCode = (expr: string) =>
+  Patterns.postalCodePattern.test(expr)
+export const isCountry = (expr: string) => Patterns.countryPattern.test(expr)
 
 // generic pattern check
 export const isPattern = (pattern: RegExp, expr: string) => pattern.test(expr)

--- a/src/types/testdata/legalentity.ts
+++ b/src/types/testdata/legalentity.ts
@@ -1,0 +1,76 @@
+/********************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+export const LEGAL_ENTITY_DATA = {
+  LEGAL_ENTITY: {
+    valid: [
+      'A', // 1 characters
+      '1234567890'.repeat(16), // 160 characters
+      'Bayerische Motoren Werke Aktiengesellschaft',
+      '7-ELEVEN INTERNATIONAL LLC',
+      '5N Plus Lübeck GmbH',
+      'Recht 24/7 Schröder Rechtsanwaltsgesellschaft mbH',
+      '+SEN Inc.', // leading special character
+      'La Poste S.A.',
+      'JPMORGAN ASIA-PACIFIC ADVANTAGE HYBRID FUND (QDII)',
+      'Currency £$€¥¢',
+      'Brackets []()',
+      'Punctuation !?,.;:',
+      'Special Characters ^&%#@*/_-\\',
+      'German: ÄÖÜß',
+      'French: ÀÉÈÊË',
+      'Spanish: ÁÉÍÓÚÑÜ',
+      'Portuguese: ÃÕÂÊÇ',
+      'Italian: ÀÈÉÌÒÙ',
+      'Danish: ÆØÅ',
+      'Swedish: ÅÄÖ',
+      'Norwegian: ÅÆØ',
+      'Finnish: ÄÖ',
+      'Icelandic: ÆÐÞ',
+      'Dutch: ÏËÏ',
+      // -- not supported by the pattern
+      // 'ACE 9 SPÓŁKA Z OGRANICZONĄ ODPOWIEDZIALNOŚCIĄ',
+      // '摩根亚太优势混合型证券投资基金 (QDII)',
+      // '삼성', // Samsung
+      // '三', // Samsung
+      // 'Czech: ČĎŇŘŠŤŽ',
+      // 'Estonian: ÄÖÜŠŽ',
+      // 'Slovak: ĽĹŔŠŤŽ',
+      // 'Polish: ĄĆĘŁŃÓŚŹŻ',
+      // 'Hungarian: ÁÉÍÓÖŐÚÜŰ',
+      // 'Romanian: ÂÎŞŢ',
+      // 'Bulgarian: ЙЪЬ',
+      // 'Greek: ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩ',
+      // 'Turkish: ÇĞİıÖŞÜ',
+      // 'Arabic: ابتثجحخدذرزسشصضطظعغفقكلمنهوي',
+      // 'Hebrew: שלום עולם',
+      // 'Hindi: अआइईउऊऋएऐओऔकखगघङचछजझञटठडढणतथदधनपफबभमयरलवशषस',
+      // 'Japanese: あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをん',
+      // 'Chinese: 你好 世界',
+      // 'Korean: 안녕하세요 세계',
+      // 'Thai: สวัสดีชาวโลก', // Thai does not seem to work even with /p{L}
+    ],
+    invalid: [
+      ' Bayerische Motoren Werke Aktiengesellschaft', // leading space
+      'Bayerische Motoren Werke Aktiengesellschaft ', // trailing space
+      'Bayerische Motoren Werke  Aktiengesellschaft', // double space
+      '', // empty
+    ],
+  },
+}

--- a/src/types/testdata/legalentity.ts
+++ b/src/types/testdata/legalentity.ts
@@ -36,6 +36,8 @@ export const LEGAL_ENTITY_DATA = {
       'Currency £$€¥¢',
       'Brackets []()',
       'Punctuation !?,.;:',
+      'Double "Quote" Company S.A.', // special character "" in name
+      'Single \'Quote\' Company LLC', // special character '' in name
       'Special Characters ^&%#@*/_-\\',
       'German: ÄÖÜß',
       'French: ÀÉÈÊË',

--- a/src/types/testdata/legalentity.ts
+++ b/src/types/testdata/legalentity.ts
@@ -22,6 +22,10 @@ export const LEGAL_ENTITY_DATA = {
     valid: [
       'A', // 1 characters
       '1234567890'.repeat(16), // 160 characters
+      // https://find-and-update.company-information.service.gov.uk/company/03249311
+      'CENTRE FOR HEALTH SCIENCES, TRAINING, RESEARCH AND DEVELOPMENT (CHESTRAD) INTERNATIONAL.',
+      // https://find-and-update.company-information.service.gov.uk/company/04120480
+      'THIS IS THE COMPANY WITH THE LONGEST NAME SO FAR INCORPORATED AT THE REGISTRY OF COMPANIES IN ENGLAND AND WALES AND ENCOMPASSING THE REGISTRIES BASED IN SCOTLAN',
       'Bayerische Motoren Werke Aktiengesellschaft',
       '7-ELEVEN INTERNATIONAL LLC',
       '5N Plus Lübeck GmbH',

--- a/src/types/testdata/legalentity.ts
+++ b/src/types/testdata/legalentity.ts
@@ -74,6 +74,8 @@ export const LEGAL_ENTITY_DATA = {
       ' Bayerische Motoren Werke Aktiengesellschaft', // leading space
       'Bayerische Motoren Werke Aktiengesellschaft ', // trailing space
       'Bayerische Motoren Werke  Aktiengesellschaft', // double space
+      'Bayerische Motoren Werke Aktiengesellschaft\n', // newline
+      'W'.repeat(161), // 161 characters
       '', // empty
     ],
   },


### PR DESCRIPTION
## Description

Extended pattern with additional currency characters and length adjustment. Tests added.

Min length: 1
Max lenth: 160

Allows " (double quote \x22) to follow back-end implementation.
Allows £$€¥¢ to allow some additional currency symbols that are used in existing companies.

## Why

Much longer company names exist than currently allowed.

Example:
https://find-and-update.company-information.service.gov.uk/company/03249311 
88 characters

## Issue

Refs: eclipse-tractusx/portal#360

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
