### PR TITLE
fix: upload docs and role selection screen next btn requires validation if no role/docs is selected

### DIFF
--- a/src/components/cax-companyRole.tsx
+++ b/src/components/cax-companyRole.tsx
@@ -25,7 +25,7 @@ import { useTranslation } from 'react-i18next'
 import { FooterButton } from './footerButton'
 import { useDispatch, useSelector } from 'react-redux'
 import { type companyRole } from '../state/features/applicationCompanyRole/types'
-import { download } from '../helpers/utils'
+import { download, isObjectEmptyOrFalsy } from '../helpers/utils'
 import UserService from '../services/UserService'
 import { getApiBase } from '../services/EnvironmentService'
 import { Notify } from './Snackbar'
@@ -83,6 +83,17 @@ export const CompanyRoleCax = () => {
     const updatedMap = { ...agreementChecked }
     updatedMap[id] = !updatedMap[id]
     setAgreementChecked(updatedMap)
+  }
+
+  const isNextBtnDisabled = () => {
+    if (companyRoleChecked && agreementChecked) {
+      if (
+        isObjectEmptyOrFalsy(companyRoleChecked) ||
+        isObjectEmptyOrFalsy(agreementChecked)
+      ) {
+        return true
+      }
+    }
   }
 
   const handleCompanyRoleCheck = (id) => {
@@ -304,6 +315,7 @@ export const CompanyRoleCax = () => {
       <FooterButton
         labelBack={t('button.back')}
         labelNext={t('button.confirm')}
+        disabled={isNextBtnDisabled()}
         handleBackClick={() => {
           backClick()
         }}

--- a/src/components/dragdrop.tsx
+++ b/src/components/dragdrop.tsx
@@ -268,6 +268,7 @@ export const DragDrop = () => {
         handleBackClick={() => {
           backClick()
         }}
+        disabled={documents?.length === 0}
         handleNextClick={() => nextClick()}
         helpUrl={
           '/documentation/?path=user%2F01.+Onboarding%2F02.+Registration%2F05.+Document+Upload.md'

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -246,3 +246,19 @@ export function handleStatusRedirect(
     else location.href = '/consent_osp'
   } else history.push('/landing')
 }
+
+export const isObjectEmptyOrFalsy = (obj) => {
+  // Check if the object is empty
+  if (Object.keys(obj).length === 0) {
+    return true
+  }
+
+  // Check if all values are false
+  for (const key in obj) {
+    if (obj[key]) {
+      return false
+    }
+  }
+
+  return true
+}


### PR DESCRIPTION
## Description
- On the role selection and upload docs screen, the next button is disabled if no role or docs is selected.
- After this user can't move to next step.

## Why
- Since there is no proper validation on Company roles and Upload docs screen which lets the user proceed without specifying Company role(s) and documents.

## Issue
https://github.com/eclipse-tractusx/portal-frontend-registration/issues/227

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
