### PR TITLE
fix: remove code that always displays error message on screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+### Bugfix
+
+- remove code that always displays error message on screen [#230](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/230)
+
 ## 2.0.1
 
 ### Change

--- a/src/components/dragdrop.tsx
+++ b/src/components/dragdrop.tsx
@@ -199,7 +199,6 @@ export const DragDrop = () => {
               <DragdropLayout
                 {...props}
                 error={fileError}
-                documentError={'documentError'}
               />
             )}
             inputContent={<DragdropContent />}

--- a/src/components/dragdropLayout.tsx
+++ b/src/components/dragdropLayout.tsx
@@ -23,7 +23,7 @@ import { useTranslation } from 'react-i18next'
 
 interface CustomLayoutProps extends ILayoutProps {
   error: string
-  documentError: string
+  documentError?: string
 }
 
 function DragdropLayout(props: CustomLayoutProps) {
@@ -32,11 +32,6 @@ function DragdropLayout(props: CustomLayoutProps) {
   return (
     <div>
       <div {...props.dropzoneProps}>{props.input}</div>
-      {props.documentError && (
-        <div className="text-danger ms-4 mt-2 fw-bold-600 fw-font-12">
-          {t('documentUpload.dragDropExceedSizeErrorMsg')}
-        </div>
-      )}
       {props.error && (
         <div className="text-danger ms-4 mt-2 fw-bold-600 fw-font-12">
           {props.error}

--- a/src/components/dragdropLayout.tsx
+++ b/src/components/dragdropLayout.tsx
@@ -19,7 +19,6 @@
  ********************************************************************************/
 
 import { type ILayoutProps } from 'react-dropzone-uploader'
-import { useTranslation } from 'react-i18next'
 
 interface CustomLayoutProps extends ILayoutProps {
   error: string
@@ -27,8 +26,6 @@ interface CustomLayoutProps extends ILayoutProps {
 }
 
 function DragdropLayout(props: CustomLayoutProps) {
-  const { t } = useTranslation()
-
   return (
     <div>
       <div {...props.dropzoneProps}>{props.input}</div>


### PR DESCRIPTION
## Description
- Removed the code that always displays the error message on this screen.
- Error should display only if the validation for the uploaded document failed.

## Why
- Registration | Upload Document : Error msg always display on screen even if no doc uploaded.

## Issue

https://github.com/eclipse-tractusx/portal-frontend-registration/issues/229

## Checklist
Also verified these cases, which works as expected:

1. Upload pdf whose size is more than 1mb
2. Upload jpg, which throw validation msg
3. Upload pdf whose size is within limit. 

Please delete options that are not relevant.

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
