### PR TITLE
fix: trailing spaces not allowed in vat id input

### DIFF
--- a/src/components/cax-companyData.tsx
+++ b/src/components/cax-companyData.tsx
@@ -683,7 +683,7 @@ export const CompanyDataCax = () => {
                       type="text"
                       value={identifierNumber}
                       onChange={(e) => {
-                        validateIdentifierNumber(e.target.value)
+                        validateIdentifierNumber(e.target.value.trim())
                       }}
                     />
                     {errors.identifierNumber && (


### PR DESCRIPTION
## Description
- This fix removes the trailing spaces for vat id.

## Why
- No warning/error message is displayed when VAT ID with trailing space is being added. 
- User is able to register company with following VAT ID having spaces  "value": "DE841338373  ". 

## Issue
- https://github.com/eclipse-tractusx/portal-frontend-registration/issues/239

## Checklist

Please delete options that are not relevant.
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
