### PR TITLE
fix(company data): remove onBlur event handler in radio identifier select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bugfix
 
 - remove logic that sets bpn before validation [#253](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/253)
-
+- fixed company data invalidation when receiving multiple identifier [247](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/247)
 
 ## 2.1.0-alpha.1
 

--- a/src/components/cax-companyData.tsx
+++ b/src/components/cax-companyData.tsx
@@ -654,9 +654,6 @@ export const CompanyDataCax = () => {
                         onChange={() => {
                           handleIdentifierSelect(id.type, id.value)
                         }}
-                        onBlur={(e) => {
-                          setIdentifierNumber(e.target.value.trim())
-                        }}
                         defaultChecked={uniqueIds[0].type === id.type}
                       />
                       <label>


### PR DESCRIPTION
## Description

Fix for bug introduced by me in: eclipse-tractusx/portal-frontend-registration#210

Remove onBlur from radio selection since this invalidated already accepted data.

## Why

OnBlur caused issues when receiving multiple identifier via BPDM and invalidated data.
<img width="566" alt="image" src="https://github.com/user-attachments/assets/f8aa2daf-0cc7-43a7-9465-c11fe1bb073e">

## Issue

Refs: #190

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes

