### PR TITLE
fix: remove logic that sets bpn before validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - country value is not updating if user moves back and forth between steps [#232](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/232)
 - remove code that always displays error message on screen [#230](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/230)
 - updated the logic for maxFiles count in upload docs step [#234](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/234)
+- remove logic that sets bpn before validation [#253](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/253)
 
 ## 2.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Bugfix
+
+- remove logic that sets bpn before validation [#253](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/253)
+
+
 ## 2.1.0-alpha.1
 
 ### Change
@@ -13,7 +18,6 @@
 - fixed country value not updating if user moves back and forth between steps [#232](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/232)
 - removed code that always displays error message on screen [#230](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/230)
 - updated the logic for maxFiles count in upload docs step [#234](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/234)
-- remove logic that sets bpn before validation [#253](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/253)
 - fixed upload docs and role selection screen - next button required validation if no role/docs is selected [#228](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/228)
 - allowed for shorter and longer german commercial register number [#216](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/216)
 

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -697,7 +697,7 @@ npm/npmjs/@mui/material/5.15.15, MIT AND CC-BY-3.0, approved, #13175
 npm/npmjs/@mui/private-theming/5.15.14, MIT AND CC-BY-3.0, approved, #13174
 npm/npmjs/@mui/styled-engine/5.15.14, MIT AND CC-BY-3.0, approved, #13173
 npm/npmjs/@mui/system/5.15.15, MIT, approved, #13170
-npm/npmjs/@mui/types/7.2.14, MIT, approved, clearlydefined
+npm/npmjs/@mui/types/7.2.14, MIT, approved, #16017
 npm/npmjs/@mui/utils/5.15.14, MIT AND OFL-1.1 AND CC-BY-3.0, approved, #13927
 npm/npmjs/@nodelib/fs.scandir/2.1.5, MIT, approved, clearlydefined
 npm/npmjs/@nodelib/fs.stat/2.0.5, MIT, approved, clearlydefined

--- a/src/components/cax-companyData.tsx
+++ b/src/components/cax-companyData.tsx
@@ -422,9 +422,6 @@ export const CompanyDataCax = () => {
                 onChange={(expr) => {
                   onSearchChange(expr)
                 }}
-                onBlur={(e) => {
-                  setBpn(e.target.value.trim())
-                }}
               />
               <label className="error-message">{bpnErrorMsg}</label>
             </div>


### PR DESCRIPTION
## Description

- Removed prop from input field that was setting the BPNL on the form without being firstly validated

## Why

When a user would insert an invalid BPNL in the autofill field, the BPNL was updating in the form despite being invalid, leading to the possibility of the user submitting the application with an incorrect BPNL. 

## Issue

#252 

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes

