### PR TITLE
build: upgrade to keycloak-js version 25

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -306,7 +306,7 @@ npm/npmjs/-/jest-validate/29.7.0, MIT, approved, clearlydefined
 npm/npmjs/-/jest-watcher/29.7.0, MIT, approved, clearlydefined
 npm/npmjs/-/jest-worker/29.7.0, MIT, approved, clearlydefined
 npm/npmjs/-/jest/29.7.0, MIT, approved, clearlydefined
-npm/npmjs/-/js-sha256/0.10.1, MIT, approved, clearlydefined
+npm/npmjs/-/js-sha256/0.11.0, MIT, approved, clearlydefined
 npm/npmjs/-/js-tokens/4.0.0, MIT, approved, #2401
 npm/npmjs/-/js-yaml/3.14.1, MIT, approved, clearlydefined
 npm/npmjs/-/js-yaml/4.1.0, MIT, approved, clearlydefined
@@ -321,7 +321,7 @@ npm/npmjs/-/json5/2.2.3, MIT, approved, #15226
 npm/npmjs/-/jsx-ast-utils/3.3.5, MIT, approved, #9209
 npm/npmjs/-/just-curry-it/5.3.0, MIT, approved, clearlydefined
 npm/npmjs/-/jwt-decode/4.0.0, MIT, approved, clearlydefined
-npm/npmjs/-/keycloak-js/23.0.7, Apache-2.0 AND MIT AND EPL-1.0 AND LicenseRef-scancode-oasis-ws-security-spec AND W3C AND LicenseRef-scancode-ws-policy-specification AND W3C AND W3C-19980720 AND (AFL-2.1 OR LGPL-2.0-only) AND (Apache-2.0 AND MIT) AND (Apache-2.0 AND MIT), approved, #11737
+npm/npmjs/-/keycloak-js/25.0.6, Apache-2.0, approved, clearlydefined
 npm/npmjs/-/keyv/4.5.4, MIT, approved, #4674
 npm/npmjs/-/kleur/3.0.3, MIT, approved, clearlydefined
 npm/npmjs/-/leven/3.1.0, MIT, approved, clearlydefined
@@ -578,8 +578,8 @@ npm/npmjs/-/yocto-queue/0.1.0, MIT, approved, clearlydefined
 npm/npmjs/@adobe/css-tools/4.4.0, MIT, approved, clearlydefined
 npm/npmjs/@ampproject/remapping/2.3.0, Apache-2.0, approved, clearlydefined
 npm/npmjs/@babel/code-frame/7.24.7, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13943
-npm/npmjs/@babel/compat-data/7.25.4, MIT, approved, clearlydefined
-npm/npmjs/@babel/core/7.25.2, MIT, approved, clearlydefined
+npm/npmjs/@babel/compat-data/7.25.4, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #16822
+npm/npmjs/@babel/core/7.25.2, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #16821
 npm/npmjs/@babel/generator/7.25.6, MIT, approved, clearlydefined
 npm/npmjs/@babel/helper-compilation-targets/7.25.2, MIT, approved, clearlydefined
 npm/npmjs/@babel/helper-module-imports/7.24.7, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13944

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "history": "^5.3.0",
     "i18next": "^23.10.1",
     "i18next-browser-languagedetector": "^7.2.0",
-    "keycloak-js": "^23.0.7",
+    "keycloak-js": "^25.0.6",
     "lodash.debounce": "^4.0.8",
     "lodash.uniq": "^4.5.0",
     "nanoid": "^5.0.6",

--- a/src/services/UserService.js
+++ b/src/services/UserService.js
@@ -49,7 +49,7 @@ const initKeycloak = (onAuthenticatedCallback) => {
       silentCheckSsoRedirectUri:
         window.location.origin + '/silent-check-sso.html',
       pkceMethod: 'S256',
-      redirectUri: `${window.location.origin}/${url}`,
+      redirectUri: `${window.location.origin}${url}`,
     })
     .then(() => {
       onAuthenticatedCallback()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2002,7 +2002,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-js@^1.3.1, base64-js@^1.5.1:
+base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -4176,10 +4176,10 @@ jest@^29.7.0:
     import-local "^3.0.2"
     jest-cli "^29.7.0"
 
-js-sha256@^0.10.1:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.10.1.tgz#b40104ba1368e823fdd5f41b66b104b15a0da60d"
-  integrity sha512-5obBtsz9301ULlsgggLg542s/jqtddfOpV5KJc4hajc9JV8GeY2gZHSVpYBn4nWqAUTJ9v+xwtbJ1mIBgIH5Vw==
+js-sha256@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.11.0.tgz#256a921d9292f7fe98905face82e367abaca9576"
+  integrity sha512-6xNlKayMZvds9h1Y1VWc0fQHQ82BxTXizWPEtEeGvmOUYpBRy4gbWroHLpzowe6xiQhHpelCQiE7HEdznyBL9Q==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -4290,13 +4290,12 @@ jwt-decode@^4.0.0:
   resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-4.0.0.tgz#2270352425fd413785b2faf11f6e755c5151bd4b"
   integrity sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==
 
-keycloak-js@^23.0.7:
-  version "23.0.7"
-  resolved "https://registry.yarnpkg.com/keycloak-js/-/keycloak-js-23.0.7.tgz#9d2fad3253e087a49573bd9ee0569e327531135c"
-  integrity sha512-OmszsKzBhhm5yP4W1q/tMd+nNnKpOAdeVYcoGhphlv8Fj1bNk4wRTYzp7pn5BkvueLz7fhvKHz7uOc33524YrA==
+keycloak-js@^25.0.6:
+  version "25.0.6"
+  resolved "https://registry.yarnpkg.com/keycloak-js/-/keycloak-js-25.0.6.tgz#ea2e74d907f251c93080c6e2245d9d858bd4b329"
+  integrity sha512-Km+dc+XfNvY6a4az5jcxTK0zPk52ns9mAxLrHj7lF3V+riVYvQujfHmhayltJDjEpSOJ4C8a57LFNNKnNnRP2g==
   dependencies:
-    base64-js "^1.5.1"
-    js-sha256 "^0.10.1"
+    js-sha256 "^0.11.0"
     jwt-decode "^4.0.0"
 
 keyv@^4.5.3:


### PR DESCRIPTION
## Description

upgrade to keycloak-js version 25
removed [`/`](https://github.com/eclipse-tractusx/portal-frontend-registration/commit/13cd8f193f7ff0015ad829946d1437e07f7647cd#diff-caa2665b4b67002c1ebbf065fbcdc17dd3b24905deced553654710a57c34b85dL52), because otherwise it is doubled in interaction with Keycloak server version 25

## Why

to align with Keycloak server version https://github.com/eclipse-tractusx/portal-iam/pull/213

## Issue

https://github.com/eclipse-tractusx/portal-iam/issues/85

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
