### PR TITLE
chore(trivy): add options according to TRG 8.04

### DIFF
--- a/.github/workflows/trivy-main.yml
+++ b/.github/workflows/trivy-main.yml
@@ -61,6 +61,9 @@ jobs:
           format: "sarif"
           output: "trivy-results1.sarif"
           vuln-type: "os,library"
+          severity: "CRITICAL,HIGH" # While vulnerabilities of all severities are reported in the SARIF output, the exit code and workflow failure are triggered only by these specified severities (CRITICAL or HIGH).
+          exit-code: "1" # Trivy exits with code 1 if vulnerabilities are found, causing the workflow step to fail.
+          limit-severities-for-sarif: true
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@f779452ac5af1c261dce0346a8f964149f49322b # v3.26.13
@@ -93,6 +96,10 @@ jobs:
           format: "sarif"
           output: "trivy-results2.sarif"
           vuln-type: "os,library"
+          severity: "CRITICAL,HIGH" # While vulnerabilities of all severities are reported in the SARIF output, the exit code and workflow failure are triggered only by these specified severities (CRITICAL or HIGH).
+          hide-progress: false
+          exit-code: "1" # Trivy exits with code 1 if vulnerabilities are found, causing the workflow step to fail.
+          limit-severities-for-sarif: true
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: always()

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -61,6 +61,9 @@ jobs:
           format: "sarif"
           output: "trivy-results1.sarif"
           vuln-type: "os,library"
+          severity: "CRITICAL,HIGH" # While vulnerabilities of all severities are reported in the SARIF output, the exit code and workflow failure are triggered only by these specified severities (CRITICAL or HIGH).
+          exit-code: "1" # Trivy exits with code 1 if vulnerabilities are found, causing the workflow step to fail.
+          limit-severities-for-sarif: true
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@f779452ac5af1c261dce0346a8f964149f49322b # v3.26.13
@@ -93,6 +96,10 @@ jobs:
           format: "sarif"
           output: "trivy-results2.sarif"
           vuln-type: "os,library"
+          severity: "CRITICAL,HIGH" # While vulnerabilities of all severities are reported in the SARIF output, the exit code and workflow failure are triggered only by these specified severities (CRITICAL or HIGH).
+          hide-progress: false
+          exit-code: "1" # Trivy exits with code 1 if vulnerabilities are found, causing the workflow step to fail.
+          limit-severities-for-sarif: true
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: always()


### PR DESCRIPTION
## Description

add "newer" options according to [TRG 8.04](https://eclipse-tractusx.github.io/docs/release/trg-8/trg-8-04)

## Why

workflow continuously runs into error: "Path does not exist: trivy-results2.sarif"

## Issue

https://github.com/eclipse-tractusx/portal/issues/467

## Checklist
 
- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
