### PR TITLE
fix(registration): update condition for disable confirm button 

### DIFF
--- a/src/components/cax-companyData.tsx
+++ b/src/components/cax-companyData.tsx
@@ -728,6 +728,8 @@ export const CompanyDataCax = () => {
           errors.country !== '' ||
           errors.postalCode !== '' ||
           errors.region !== '' ||
+          !identifierType ||
+          identifierNumber.length === 0 ||
           !identifierDetails?.length ||
           errors.identifierNumber !== ''
         }


### PR DESCRIPTION
## Description

confirm button should not be enabled until identifier type and identifier number is entered.

**Changelog**
 
 **Registration Form**
   - fixed disable confirm button issue for mandatory fields

## Why

confirm button is enabled even though identifier type and identifier number fields empty

## Issue

#302 

## Checklist

Please delete options that are not relevant.

- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [ ] I have performed a self-review of my own code
- [ ] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
