### PR TITLE
fix(registration): break email word to the next line

### DIFF
--- a/src/styles/newApp.css
+++ b/src/styles/newApp.css
@@ -493,6 +493,7 @@ textarea {
   color: #252525;
   font-size: 16px;
   font-family: 'Libre Franklin 400', sans-serif;
+  overflow-wrap: break-word;
 }
 
 .list-group-item-role {


### PR DESCRIPTION
## Description

update style of email text to support break word to next line

**Changelog**
 
 **Registration Form**
   - fixed email text break word issue

## Why

email text is overlapping with button

## Issue

#303 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
