### PR TITLE
docs: fix how to contribute link

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ Link to Github issue.
 
 Please delete options that are not relevant.
 
-- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
+- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
 - [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
 - [ ] I have created and linked IP issues or requested their creation by a committer
 - [ ] I have performed a self-review of my own code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ https://www.eclipse.org/projects/handbook/#resources-commit
 
 ## How To Contribute
 
-For more practical information, please refer to [Contribution details](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md).
+For more practical information, please refer to [Contribution details](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md).
 
 ## Contact
 


### PR DESCRIPTION
## Description

Fix the "How to Contribute" link.

## Why

The existing link is broken.

## Issue

[Issue #483](https://github.com/eclipse-tractusx/portal/issues/483) 

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have successfully tested my changes locally
