### PR TITLE
chore(dependencies workflow): refactor dependency conflict resolution logic

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -53,18 +53,6 @@ jobs:
       - name: Generate Dependencies file
         run: java -jar ./scripts/download/org.eclipse.dash.licenses-1.1.1.jar yarn.lock -project automotive.tractusx -summary DEPENDENCIES || true
 
-      - name: Check if dependencies were changed
-        id: dependencies-changed
-        run: |
-          changed=$(git diff DEPENDENCIES)
-          if [[ -n "$changed" ]]; then
-            echo "dependencies changed"
-            echo "changed=true" >> $GITHUB_OUTPUT
-          else
-            echo "dependencies not changed"
-            echo "changed=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Check for restricted dependencies
         run: |
           restricted=$(grep ' restricted,' DEPENDENCIES || true)
@@ -72,16 +60,12 @@ jobs:
             echo "The following dependencies are restricted: $restricted"
             exit 1
           fi
-        if: steps.dependencies-changed.outputs.changed == 'true'
 
       - name: Upload DEPENDENCIES file
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           path: DEPENDENCIES
-        if: steps.dependencies-changed.outputs.changed == 'true'
 
       - name: Signal need to update DEPENDENCIES
         run: |
           echo "Dependencies need to be updated (updated DEPENDENCIES file has been uploaded to workflow run)"
-          exit 1
-        if: steps.dependencies-changed.outputs.changed == 'true'


### PR DESCRIPTION
## Description

Update obsolete logic in Dependencies.yaml for "**Check if dependencies were changed**".

## Why

After the improvement done during of https://github.com/eclipse-tractusx/portal-frontend/issues/1306, it is  noticed that the [check if the dependencies file was changed](https://github.com/eclipse-tractusx/portal-frontend/blob/v2.3.0/.github/workflows/dependencies.yaml#L46) is obsolete. 
The relevant steps affected by this constraint should be executed every time the workflow is triggered.

```
- **Dependencies Workflow**:
  - Update logic for Dependencies workflow [#359](https://github.com/eclipse-tractusx/portal-frontend/pull/359)
```


## Issue

https://github.com/eclipse-tractusx/portal-frontend-registration/issues/359

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
