### PR TITLE
feat(pattern): update German commercial registration number regex to allow underscores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Feature
 
 - updated validation of region code for tagus release [#357](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/357)
-- allow underscores in german crn [#364](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/364)
+- allow underscores in german commercial registration number [#364](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/364)
 
 ### Bugfix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### Feature
 
-- updated validation of region code for tagus release [#1513](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/357)
+- updated validation of region code for tagus release [#357](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/357)
+- allow underscores in german crn [#364](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/364)
 
 ### Bugfix
 

--- a/src/locales/de/translations.json
+++ b/src/locales/de/translations.json
@@ -76,7 +76,7 @@
     "IN_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with hyphen with 4 to 21 digits.",
     "IN_VAT_ID": "Please enter a valid number. Hint: Alphanumeric with hyphen with 5 to 15 digits.",
     "IN_LEI_CODE": "Please enter a valid number. Hint: Alphanumeric with exact 20 digits.",
-    "DE_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with hyphen, underscore and space.",
+    "DE_COMMERCIAL_REG_NUMBER": "Please enter a valid identifier. Hint: Starting with court name or code and followed by registered identifier.",
     "DE_VAT_ID": "Please enter a valid number. Hint: Starting with DE and followed by 9 digit numbers",
     "DE_LEI_CODE": "Please enter a valid number. Hint: Alphanumeric with exact 20 digits.",
     "FR_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with space with 14 to 17 digits.",

--- a/src/locales/de/translations.json
+++ b/src/locales/de/translations.json
@@ -76,7 +76,7 @@
     "IN_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with hyphen with 4 to 21 digits.",
     "IN_VAT_ID": "Please enter a valid number. Hint: Alphanumeric with hyphen with 5 to 15 digits.",
     "IN_LEI_CODE": "Please enter a valid number. Hint: Alphanumeric with exact 20 digits.",
-    "DE_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with hyphen and space.",
+    "DE_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with hyphen, underscore and space.",
     "DE_VAT_ID": "Please enter a valid number. Hint: Starting with DE and followed by 9 digit numbers",
     "DE_LEI_CODE": "Please enter a valid number. Hint: Alphanumeric with exact 20 digits.",
     "FR_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with space with 14 to 17 digits.",

--- a/src/locales/en/translations.json
+++ b/src/locales/en/translations.json
@@ -76,7 +76,7 @@
     "IN_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with hyphen with 4 to 21 digits.",
     "IN_VAT_ID": "Please enter a valid number. Hint: Alphanumeric with hyphen with 5 to 15 digits.",
     "IN_LEI_CODE": "Please enter a valid number. Hint: Alphanumeric with exact 20 digits.",
-    "DE_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with hyphen, underscore and space.",
+    "DE_COMMERCIAL_REG_NUMBER": "Please enter a valid identifier. Hint: Starting with court name or code and followed by registered identifier.",
     "DE_VAT_ID": "Please enter a valid number. Hint: Starting with DE and followed by 9 digit numbers",
     "DE_LEI_CODE": "Please enter a valid number. Hint: Alphanumeric with exact 20 digits.",
     "FR_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with space with 14 to 17 digits.",

--- a/src/locales/en/translations.json
+++ b/src/locales/en/translations.json
@@ -76,7 +76,7 @@
     "IN_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with hyphen with 4 to 21 digits.",
     "IN_VAT_ID": "Please enter a valid number. Hint: Alphanumeric with hyphen with 5 to 15 digits.",
     "IN_LEI_CODE": "Please enter a valid number. Hint: Alphanumeric with exact 20 digits.",
-    "DE_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with hyphen and space.",
+    "DE_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with hyphen, underscore and space.",
     "DE_VAT_ID": "Please enter a valid number. Hint: Starting with DE and followed by 9 digit numbers",
     "DE_LEI_CODE": "Please enter a valid number. Hint: Alphanumeric with exact 20 digits.",
     "FR_COMMERCIAL_REG_NUMBER": "Please enter a valid number. Hint: Alphanumeric with space with 14 to 17 digits.",

--- a/src/types/Patterns.ts
+++ b/src/types/Patterns.ts
@@ -39,7 +39,7 @@ const VAT_ID = {
   MX: /^[a-zA-Z\d-&]{12,13}$/,
 }
 const COMMERCIAL_REG_NUMBER = {
-  Worldwide: /^(?!.*\s$)([A-Za-zÀ-ÿ0-9.()](\.|\s|-)?){4,50}$/, // generic pattern
+  Worldwide: /^(?!.*\s$)([A-Za-zÀ-ÿ0-9.()](\.|\s|-|_)?){4,50}$/, // generic pattern
   DE: /^(?!.*\s$)([A-Za-zÀ-ÿ0-9.()](\s|-|_)?){4,50}$/,
   FR: /^(?!.*\s$)([A-Za-z0-9]\s?){14,17}$/,
 }

--- a/src/types/Patterns.ts
+++ b/src/types/Patterns.ts
@@ -40,7 +40,7 @@ const VAT_ID = {
 }
 const COMMERCIAL_REG_NUMBER = {
   Worldwide: /^(?!.*\s$)([A-Za-zÀ-ÿ0-9.()](\.|\s|-|_)?){4,50}$/, // generic pattern
-  DE: /^(?!.*\s$)([A-Za-zÀ-ÿ0-9.()](\s|-|_)?){4,50}$/,
+  DE: /^(?!.*\s$)([A-Za-zÀ-ÿ])([A-Za-zÀ-ÿ0-9.()](\s|-|_)?){4,50}$/,
   FR: /^(?!.*\s$)([A-Za-z0-9]\s?){14,17}$/,
 }
 

--- a/src/types/Patterns.ts
+++ b/src/types/Patterns.ts
@@ -40,7 +40,7 @@ const VAT_ID = {
 }
 const COMMERCIAL_REG_NUMBER = {
   Worldwide: /^(?!.*\s$)([A-Za-zÀ-ÿ0-9.()](\.|\s|-)?){4,50}$/, // generic pattern
-  DE: /^(?!.*\s$)([A-Za-zÀ-ÿ0-9.()](\s|-)?){4,50}$/,
+  DE: /^(?!.*\s$)([A-Za-zÀ-ÿ0-9.()](\s|-|_)?){4,50}$/,
   FR: /^(?!.*\s$)([A-Za-z0-9]\s?){14,17}$/,
 }
 

--- a/src/types/testdata/crn.ts
+++ b/src/types/testdata/crn.ts
@@ -20,9 +20,6 @@
 export const CRN_TEST_DATA = {
   DE: {
     valid: [
-      '123456789',
-      '987654321',
-      '000000000',
       // Valid records found at https://www.unternehmensregister.de/ureg/ (German Handelsregister)
       'HRB 209459',
       'HRB 86891',

--- a/src/types/testdata/crn.ts
+++ b/src/types/testdata/crn.ts
@@ -47,6 +47,9 @@ export const CRN_TEST_DATA = {
     invalid: [
       '', // empty
       ' ', // whitespace
+      '123', // too short
+      'Ludwigshafen a.Rhein (Ludwigshafen) HRB1234567890123456789', // too long
+      '123456789', // numbers only
       '123456789 ', // trailing whitespace
       ' 123456789', // leading whitespace
       '12345  6789', // invalid character (double whitespace)

--- a/src/types/testdata/crn.ts
+++ b/src/types/testdata/crn.ts
@@ -21,6 +21,7 @@ export const CRN_TEST_DATA = {
   DE: {
     valid: [
       // Valid records found at https://www.unternehmensregister.de/ureg/ (German Handelsregister)
+      // Identifier without court is discouraged - can lead to duplicate findings
       'HRB 209459',
       'HRB 86891',
       'HRA 5778',
@@ -30,12 +31,15 @@ export const CRN_TEST_DATA = {
       'HRB 42', // Südzucker AG
       'HRA 3679 FL',
       'HRB 209459 B',
+      // Identifier with court is recommended but has some chance of failing automatic validation
+      'Mannheim HRB 42', // Südzucker AG
       'München HRB 175450',
       'Frankfurt am Main HRB 134317',
       'Oldenburg (Oldenburg) VR 1706',
       'Ludwigshafen a.Rhein (Ludwigshafen) VR 60423',
       'Weiden i. d. OPf. HRB 4339',
       'Berlin-Charlottenburg HRB 98814',
+      // Identifier with unique court code has the highest probability of success
       'F1103R_HRB98814',
       'F1103R_HRB241059',
       'T2408V_HRB46288',

--- a/src/types/testdata/crn.ts
+++ b/src/types/testdata/crn.ts
@@ -93,8 +93,6 @@ export const CRN_TEST_DATA = {
   },
   Worldwide: {
     valid: [
-      'DE123456789',
-      'FR12345678901',
       'ABC20010101AAA',
       '10BBBCH5678G1Z9',
       '37AAACP2678Q1ZP',
@@ -104,9 +102,9 @@ export const CRN_TEST_DATA = {
     invalid: [
       '', // empty
       ' ', // whitespace
-      ' DE123456789', // leading space
-      'DE123456789 ', // trailing space
-      'DE  123456789', // invalid character (double whitespace)
+      ' ABC20010101AAA', // leading space
+      'ABC20010101AAA ', // trailing space
+      'ABC  20010101AAA', // invalid character (double whitespace)
     ],
   },
 }

--- a/src/types/testdata/crn.ts
+++ b/src/types/testdata/crn.ts
@@ -39,9 +39,9 @@ export const CRN_TEST_DATA = {
       'Ludwigshafen a.Rhein (Ludwigshafen) VR 60423',
       'Weiden i. d. OPf. HRB 4339',
       'Berlin-Charlottenburg HRB 98814',
-      'F1103R_HRB98814', // German CRN with court code
-      'F1103R_HRB241059', // German CRN with court code
-      'T2408V_HRB46288', // German CRN with court code
+      'F1103R_HRB98814',
+      'F1103R_HRB241059',
+      'T2408V_HRB46288',
     ],
     invalid: [
       '', // empty

--- a/src/types/testdata/crn.ts
+++ b/src/types/testdata/crn.ts
@@ -39,6 +39,9 @@ export const CRN_TEST_DATA = {
       'Ludwigshafen a.Rhein (Ludwigshafen) VR 60423',
       'Weiden i. d. OPf. HRB 4339',
       'Berlin-Charlottenburg HRB 98814',
+      'F1103R_HRB98814', // German CRN with court code
+      'F1103R_HRB241059', // German CRN with court code
+      'T2408V_HRB46288', // German CRN with court code
     ],
     invalid: [
       '', // empty


### PR DESCRIPTION
## Description

Adjusted pattern for german crn with underscore separated court code and identifier.

## Why

Clearing house allows courts to use underscores in the commercial registration number.

## Issue

Refs: eclipse-tractusx/portal-frontend-registration#362
Depends on: eclipse-tractusx/portal-backend#1311

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
