### PR TITLE
fix: add utf normalization on text fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - **Registration Form**
   - fixed disable confirm button issue for mandatory fields [#304](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/304)
   - fixed email text break word issue [#305](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/305)
+  - normalise utf codes on all text input fields [#367](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/367)
 
 ## 2.1.0
 
@@ -66,15 +67,18 @@
 ## 2.0.0
 
 ### Change
+
 - Pattern updates
   - Support special characters in the registration form - Name, street, region, city and postal code
   - updated company region field to accept hyphens
- 
+
 ### Feature
+
 - Registration Step "Select Company Role"
   - added support for optional and inactive agreements based on received backend response ![Tag](https://img.shields.io/static/v1?label=&message=Pre-Release&color=grey&style=flat)
- 
+
 ### Technical Support
+
 - migrated from Create React App (webpack) to Vite (rollup)
   - switched from deprecated CRA to new framework for build scripts and development server
   - use React 18 instead of 17
@@ -94,6 +98,7 @@
 ## 1.6.0
 
 ### Change
+
 - Changed API calls to use RTK queries for improved performance and code organization
 - Removed references to consortia environments
 - Updated documentation and help links to reflect the updated directory structure in portal-assets
@@ -101,6 +106,7 @@
 - Replaced the country input field in step 1 with a country select list; including an auto-complete functionality
 
 ### Technical Support
+
 - Upgraded dependencies to address vulnerabilities in axios, follow-redirects, postcss, @adobe/css-tools, and serialize-javascript
 - Added a build check at pull request to ensure code quality and prevent issues in the future
 - Updated the file header template
@@ -112,6 +118,7 @@
   - referenced docker notice files in notice section instead of duplicating the content
 
 ### Bugfix
+
 - Added an asterisk to the identifier type select field to indicate the required field
 - Fixed the user logout redirect; ensuring users are properly redirected after logging out
 - Fixed error handling configuration for all page components to display backend errors to the user in all cases
@@ -120,338 +127,421 @@
 ## 1.5.4
 
 ### Change
+
 - Legal information for distributions [TRG 7.05](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-05/)
   - added legal info at build
 
 ### Bugfix
-* updated verify registration help link with valid link
+
+- updated verify registration help link with valid link
 
 ### Technical Support
+
 - added pull request linting
 
 ### Known Knowns
+
 - Backend api errors are partially not handled on FE side, user receives on certain system error scenarios no message on the UI (e.g. if the GET /companyRoles has issues to fetch the already selected roles from the backend) - the issue only appears if the FE and BE are not correctly integrated or if the backend has business logic issues/db service issues
 
 ## 1.5.3
 
 ### Change
+
 n/a
 
 ### Feature
+
 n/a
 
 ### Technical Support
+
 - Trivy scan: changed to no failure on high findings, as it should only fail if there is an error/misconfiguration
 
 ### Bugfix
+
 - Vulnerability from dependency
   - upgrade axios dependency from 0.27.2 to v1.6.1 and implement changes due to major version upgrade
 - Sonar - fixed low bugs
 - Company Registration - Submit button logic of the registration submission updated to handle "inactive"/"disabled" state in case of missing document upload
 
 ### Known Knowns
+
 - Backend api errors are partially not handled on FE side, user receives on certain system error scenarios no message on the UI (e.g. if the GET /companyRoles has issues to fetch the already selected roles from the backend) - the issue only appears if the FE and BE are not correctly integrated or if the backend has business logic issues/db service issues
 
 ## 1.5.2
 
 ### Change
-* updated help links with valid help application hyperlinks
+
+- updated help links with valid help application hyperlinks
 
 ### Feature
+
 n/a
 
 ### Technical Support
+
 - upgraded dependencies to latest version
 
 ### Bugfix
+
 - Vulnerability from dependency
   - Set resolution for @babel/traverse (CVE-2023-45133), for axios and css-what
 - Company Role Select Form Step - updated OSP value to human readable text instead of displaying technical keys
 
 ### Known Knowns
+
 - Backend api errors are partially not handled on FE side, user receives on certain system error scenarios no message on the UI (e.g. if the GET /companyRoles has issues to fetch the already selected roles from the backend) - the issue only appears if the FE and BE are not correctly integrated or if the backend has business logic issues/db service issues
 
 ## 1.5.1
 
 ### Change
-* updated translations
+
+- updated translations
 
 ### Technical Support
-* Build images also for arm64, in addition to amd64
-* Security.md updated
-* npm-get-version action updated 
+
+- Build images also for arm64, in addition to amd64
+- Security.md updated
+- npm-get-version action updated
 
 ## 1.5.0
 
 ### Changes
-* removed country_de property from all api connected business logics and UI field
-* Company Data Step
-  * enabled change of country identifier for pre-saved company data
-  * enhanced 'City' and 'Region' input patterns to allow numeric values on top
-* Company Data Step
-  * enhanced 'City' and 'Region' input patterns to allow numeric values
-* System Behavior
-  * Add Company Data (Step 1) input field "Country Code" case sensitive function disabled
-  * Enhanced "Invite" button to display load element till backend response is received
+
+- removed country_de property from all api connected business logics and UI field
+- Company Data Step
+  - enabled change of country identifier for pre-saved company data
+  - enhanced 'City' and 'Region' input patterns to allow numeric values on top
+- Company Data Step
+  - enhanced 'City' and 'Region' input patterns to allow numeric values
+- System Behavior
+  - Add Company Data (Step 1) input field "Country Code" case sensitive function disabled
+  - Enhanced "Invite" button to display load element till backend response is received
 
 ### Feature
+
 n/a
 
 ### Technical Support
+
 - changed license notice for images
 - changed container registry for Trivy scan to Docker Hub
 
 ### Bugfix
+
 - fixed code smells and bugs from Sonarcloud
 - upgraded dependencies and set resolution for tough-cookie library to v4.1.3
 
 ### Known Knowns
+
 - Company Data (Step 1) input field "street" does not allow special characters such as specific polish letters
 
 ## 1.4.0
 
 ### Feature
-* About page for legal notice
-   * About card added
-   * About page added and linked in footer component
-   * card component integrated in About page
-* Third-party-licenses page removed (replaced by About page)
+
+- About page for legal notice
+  - About card added
+  - About page added and linked in footer component
+  - card component integrated in About page
+- Third-party-licenses page removed (replaced by About page)
 
 ### Technical Support
-* About page
-   * enabled build and release workflows to provide content
+
+- About page
+  - enabled build and release workflows to provide content
 
 ## 1.3.1
 
 ### Change
+
 n/a
 
 ### Feature
+
 n/a
 
 ### Technical Support
-* changed release workflow to retrieve tag from github.ref_name (set-output command deprecated)
-* added release workflow for release-candidates
-* changed container registry to Docker Hub
-* added pull request template
+
+- changed release workflow to retrieve tag from github.ref_name (set-output command deprecated)
+- added release workflow for release-candidates
+- changed container registry to Docker Hub
+- added pull request template
 
 ### Bugfix
-* added support for multiline in personal note field
+
+- added support for multiline in personal note field
 
 ## 1.3.0
 
 ### Change
-* Updating style for /nextStep page (beautify UI)
-* Company Role Step – document download used api endpoint path updated
+
+- Updating style for /nextStep page (beautify UI)
+- Company Role Step – document download used api endpoint path updated
 
 ### Feature
+
 n/a
 
 ### Technical Support
-* added temp fix for CVE-2023-0464
-* added build workflow for v1.3.0 release candidate phase
-* updated actions workflows
+
+- added temp fix for CVE-2023-0464
+- added build workflow for v1.3.0 release candidate phase
+- updated actions workflows
 
 ### Bugfix
+
 n/a
 
 ## 1.2.0
 
 ### Change
-* Visually highlight mandatory company data input fields
-* Update "Submit" registration button to support delays, network latency via loading element
+
+- Visually highlight mandatory company data input fields
+- Update "Submit" registration button to support delays, network latency via loading element
 
 ### Feature
+
 n/a
 
 ### Technical Support
-* Change local port to run behind reverse proxy
+
+- Change local port to run behind reverse proxy
 
 ### Bugfix
+
 n/a
 
 ## 1.1.0
 
 ### Change
-* Updated registration "Submit" button to load button
+
+- Updated registration "Submit" button to load button
 
 ### Feature
-* Company Data - added region field optionally as well as mandatory for a given number of countries
-* Released error page for 4xx and 5xx errors when accessing/loading the registration app
+
+- Company Data - added region field optionally as well as mandatory for a given number of countries
+- Released error page for 4xx and 5xx errors when accessing/loading the registration app
 
 ### Technical Support
-* Added temp fix for CVE-2023-23916
+
+- Added temp fix for CVE-2023-23916
 
 ### Bugfix
-* Company Data - display company name as 'Legal Entity Name' and 'Registered Name'
-* Company Data - errors displayed for "bpn does not exist" reduced to input field error only, additionally style updated
-* Company Data - confirm button disabled till all company data are added
+
+- Company Data - display company name as 'Legal Entity Name' and 'Registered Name'
+- Company Data - errors displayed for "bpn does not exist" reduced to input field error only, additionally style updated
+- Company Data - confirm button disabled till all company data are added
 
 ## 1.0.0-RC6
 
 ### Change
+
 n/a
 
 ### Feature
+
 n/a
 
 ### Technical Support
+
 n/a
 
 ### Bugfix
-* Fix redirect url issue in case of redirection to portal homepage
-* Updated regular expression of street name pattern for company data input field
-* Fix unique identifier display option for bpdm company data autofill
+
+- Fix redirect url issue in case of redirection to portal homepage
+- Updated regular expression of street name pattern for company data input field
+- Fix unique identifier display option for bpdm company data autofill
 
 ## 1.0.0-RC5
 
 ### Change
+
 n/a
 
 ### Feature
-* Redirect user to "closed"; "under validation" or portal page based on application status 
+
+- Redirect user to "closed"; "under validation" or portal page based on application status
 
 ### Technical Support
+
 n/a
 
 ### Bugfix
-* Company Data Unique Identifier field value irritation when entering the unique identifier value
+
+- Company Data Unique Identifier field value irritation when entering the unique identifier value
 
 ## 1.0.0-RC4
 
 ### Change
+
 n/a
 
 ### Feature
+
 n/a
 
 ### Technical Support
-* resolve dependabot finding
-* temp fix for cve-2023-0286
-* add missing '--no-cache': apk update && apk add
+
+- resolve dependabot finding
+- temp fix for cve-2023-0286
+- add missing '--no-cache': apk update && apk add
 
 ### Bugfix
-* Change companyRoleAgreementData API response (new structure of the response body)
-* Company Data Unique Identifier
-  * Identifier type ui issue when entering the value fixed
-  * Identifier number change enabled even after initial save
-  * Identifier number pattern error validation updated (fe)
+
+- Change companyRoleAgreementData API response (new structure of the response body)
+- Company Data Unique Identifier
+  - Identifier type ui issue when entering the value fixed
+  - Identifier number change enabled even after initial save
+  - Identifier number pattern error validation updated (fe)
 
 ## 1.0.0-RC3
 
 ### Change
-* add error pop-up for step 3 - select company role and commit to t&c's
-* city data input pattern updated
+
+- add error pop-up for step 3 - select company role and commit to t&c's
+- city data input pattern updated
 
 ### Feature
+
 n/a
 
 ### Technical Support
+
 n/a
 
 ### Bugfix
-* help page handling
-* CVE-2022-46175 - Prototype Pollution in JSON5 via Parse Method - upgraded all dependencies
+
+- help page handling
+- CVE-2022-46175 - Prototype Pollution in JSON5 via Parse Method - upgraded all dependencies
 
 ## 1.0.0-RC2
 
 ### Change
+
 n/a
 
 ### Feature
-* enabled company data input form to support unique identifier handling for companies based on company location country code. ![Tag](https://img.shields.io/static/v1?label=&message=Pre-Release&color=grey&style=flat)
+
+- enabled company data input form to support unique identifier handling for companies based on company location country code. ![Tag](https://img.shields.io/static/v1?label=&message=Pre-Release&color=grey&style=flat)
 
 ### Technical Support
+
 n/a
 
 ### Bugfix
-* translation fixes on static text values
+
+- translation fixes on static text values
 
 ## 1.0.0-RC1
 
 ### Change
-* implemented in the step 1 "company data" error handling for unsuccessful company data save function
+
+- implemented in the step 1 "company data" error handling for unsuccessful company data save function
 
 ### Feature
+
 n/a
 
 ### Technical Support
+
 n/a
 
 ### Bugfix
+
 n/a
 
 ## 0.10.0
 
 ### Change
-* updated postal code validation for registration step 1 to allow international codes
-* update of company role agreement frontend logic to display agreements with and without documents
+
+- updated postal code validation for registration step 1 to allow international codes
+- update of company role agreement frontend logic to display agreements with and without documents
 
 ### Feature
+
 n/a
 
 ### Technical Support
+
 n/a
 
 ### Bugfix
+
 n/a
 
 ## 0.9.0
 
 ### Change
-* updated document deletion endpoint (from administration service to registration service) and added error/success messages
+
+- updated document deletion endpoint (from administration service to registration service) and added error/success messages
 
 ### Feature
+
 n/a
 
 ### Technical Support
+
 n/a
 
 ### Bugfix
-* Added missing image to the registration finished / successfully submitted page
+
+- Added missing image to the registration finished / successfully submitted page
 
 ## 0.8.0
 
 ### Change
+
 n/a
 
 ### Feature
-* Registration Step 3 (company role and consent agreement); fetching agreement document from the portal backend and enabling direct document download.
+
+- Registration Step 3 (company role and consent agreement); fetching agreement document from the portal backend and enabling direct document download.
 
 ### Technical Support
+
 n/a
 
 ### Bugfix
-* Registration submission validations as well as registration request validation enhanced/fixed.
+
+- Registration submission validations as well as registration request validation enhanced/fixed.
 
 ## 0.7.0
 
 ### Change
+
 n/a
 
 ### Feature
-* Company registration submission for companies without BPN got activated.
+
+- Company registration submission for companies without BPN got activated.
 
 ### Technical Support
+
 n/a
 
 ### Bugfix
-* Registration Step 1 "Company Data Input Form": Country input field updated to country code incl. input validation
+
+- Registration Step 1 "Company Data Input Form": Country input field updated to country code incl. input validation
 
 ## 0.6.0
 
 ### Change
-* n/a
+
+- n/a
 
 ### Feature
-* Registration Welcome: Introduction of a welcome page including a "how to" for the following registration steps
-* Registration Submission: Support of the registration submission incl. new page for successful submission and triggered email to the registrator
-* Registration Closed Function: Company registrations in status "submitted", "approved" or "declined" cannot re-visit the registration document. A closed registration information gets displayed.
+
+- Registration Welcome: Introduction of a welcome page including a "how to" for the following registration steps
+- Registration Submission: Support of the registration submission incl. new page for successful submission and triggered email to the registrator
+- Registration Closed Function: Company registrations in status "submitted", "approved" or "declined" cannot re-visit the registration document. A closed registration information gets displayed.
 
 ### Technical Support
-* n/a
+
+- n/a
 
 ### Bugfix
-* Bugfix - Add company data - payload update to include bpn when posting the company data
-* Bugfix - Submit registration - added applicationId into the post job
-* Bugfix - Company Roles - company role description moved from hardcoded values to api (db)
+
+- Bugfix - Add company data - payload update to include bpn when posting the company data
+- Bugfix - Submit registration - added applicationId into the post job
+- Bugfix - Company Roles - company role description moved from hardcoded values to api (db)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,18 +67,15 @@
 ## 2.0.0
 
 ### Change
-
 - Pattern updates
   - Support special characters in the registration form - Name, street, region, city and postal code
   - updated company region field to accept hyphens
-
+ 
 ### Feature
-
 - Registration Step "Select Company Role"
   - added support for optional and inactive agreements based on received backend response ![Tag](https://img.shields.io/static/v1?label=&message=Pre-Release&color=grey&style=flat)
-
+ 
 ### Technical Support
-
 - migrated from Create React App (webpack) to Vite (rollup)
   - switched from deprecated CRA to new framework for build scripts and development server
   - use React 18 instead of 17
@@ -98,7 +95,6 @@
 ## 1.6.0
 
 ### Change
-
 - Changed API calls to use RTK queries for improved performance and code organization
 - Removed references to consortia environments
 - Updated documentation and help links to reflect the updated directory structure in portal-assets
@@ -106,7 +102,6 @@
 - Replaced the country input field in step 1 with a country select list; including an auto-complete functionality
 
 ### Technical Support
-
 - Upgraded dependencies to address vulnerabilities in axios, follow-redirects, postcss, @adobe/css-tools, and serialize-javascript
 - Added a build check at pull request to ensure code quality and prevent issues in the future
 - Updated the file header template
@@ -118,7 +113,6 @@
   - referenced docker notice files in notice section instead of duplicating the content
 
 ### Bugfix
-
 - Added an asterisk to the identifier type select field to indicate the required field
 - Fixed the user logout redirect; ensuring users are properly redirected after logging out
 - Fixed error handling configuration for all page components to display backend errors to the user in all cases
@@ -127,421 +121,338 @@
 ## 1.5.4
 
 ### Change
-
 - Legal information for distributions [TRG 7.05](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-05/)
   - added legal info at build
 
 ### Bugfix
-
-- updated verify registration help link with valid link
+* updated verify registration help link with valid link
 
 ### Technical Support
-
 - added pull request linting
 
 ### Known Knowns
-
 - Backend api errors are partially not handled on FE side, user receives on certain system error scenarios no message on the UI (e.g. if the GET /companyRoles has issues to fetch the already selected roles from the backend) - the issue only appears if the FE and BE are not correctly integrated or if the backend has business logic issues/db service issues
 
 ## 1.5.3
 
 ### Change
-
 n/a
 
 ### Feature
-
 n/a
 
 ### Technical Support
-
 - Trivy scan: changed to no failure on high findings, as it should only fail if there is an error/misconfiguration
 
 ### Bugfix
-
 - Vulnerability from dependency
   - upgrade axios dependency from 0.27.2 to v1.6.1 and implement changes due to major version upgrade
 - Sonar - fixed low bugs
 - Company Registration - Submit button logic of the registration submission updated to handle "inactive"/"disabled" state in case of missing document upload
 
 ### Known Knowns
-
 - Backend api errors are partially not handled on FE side, user receives on certain system error scenarios no message on the UI (e.g. if the GET /companyRoles has issues to fetch the already selected roles from the backend) - the issue only appears if the FE and BE are not correctly integrated or if the backend has business logic issues/db service issues
 
 ## 1.5.2
 
 ### Change
-
-- updated help links with valid help application hyperlinks
+* updated help links with valid help application hyperlinks
 
 ### Feature
-
 n/a
 
 ### Technical Support
-
 - upgraded dependencies to latest version
 
 ### Bugfix
-
 - Vulnerability from dependency
   - Set resolution for @babel/traverse (CVE-2023-45133), for axios and css-what
 - Company Role Select Form Step - updated OSP value to human readable text instead of displaying technical keys
 
 ### Known Knowns
-
 - Backend api errors are partially not handled on FE side, user receives on certain system error scenarios no message on the UI (e.g. if the GET /companyRoles has issues to fetch the already selected roles from the backend) - the issue only appears if the FE and BE are not correctly integrated or if the backend has business logic issues/db service issues
 
 ## 1.5.1
 
 ### Change
-
-- updated translations
+* updated translations
 
 ### Technical Support
-
-- Build images also for arm64, in addition to amd64
-- Security.md updated
-- npm-get-version action updated
+* Build images also for arm64, in addition to amd64
+* Security.md updated
+* npm-get-version action updated 
 
 ## 1.5.0
 
 ### Changes
-
-- removed country_de property from all api connected business logics and UI field
-- Company Data Step
-  - enabled change of country identifier for pre-saved company data
-  - enhanced 'City' and 'Region' input patterns to allow numeric values on top
-- Company Data Step
-  - enhanced 'City' and 'Region' input patterns to allow numeric values
-- System Behavior
-  - Add Company Data (Step 1) input field "Country Code" case sensitive function disabled
-  - Enhanced "Invite" button to display load element till backend response is received
+* removed country_de property from all api connected business logics and UI field
+* Company Data Step
+  * enabled change of country identifier for pre-saved company data
+  * enhanced 'City' and 'Region' input patterns to allow numeric values on top
+* Company Data Step
+  * enhanced 'City' and 'Region' input patterns to allow numeric values
+* System Behavior
+  * Add Company Data (Step 1) input field "Country Code" case sensitive function disabled
+  * Enhanced "Invite" button to display load element till backend response is received
 
 ### Feature
-
 n/a
 
 ### Technical Support
-
 - changed license notice for images
 - changed container registry for Trivy scan to Docker Hub
 
 ### Bugfix
-
 - fixed code smells and bugs from Sonarcloud
 - upgraded dependencies and set resolution for tough-cookie library to v4.1.3
 
 ### Known Knowns
-
 - Company Data (Step 1) input field "street" does not allow special characters such as specific polish letters
 
 ## 1.4.0
 
 ### Feature
-
-- About page for legal notice
-  - About card added
-  - About page added and linked in footer component
-  - card component integrated in About page
-- Third-party-licenses page removed (replaced by About page)
+* About page for legal notice
+   * About card added
+   * About page added and linked in footer component
+   * card component integrated in About page
+* Third-party-licenses page removed (replaced by About page)
 
 ### Technical Support
-
-- About page
-  - enabled build and release workflows to provide content
+* About page
+   * enabled build and release workflows to provide content
 
 ## 1.3.1
 
 ### Change
-
 n/a
 
 ### Feature
-
 n/a
 
 ### Technical Support
-
-- changed release workflow to retrieve tag from github.ref_name (set-output command deprecated)
-- added release workflow for release-candidates
-- changed container registry to Docker Hub
-- added pull request template
+* changed release workflow to retrieve tag from github.ref_name (set-output command deprecated)
+* added release workflow for release-candidates
+* changed container registry to Docker Hub
+* added pull request template
 
 ### Bugfix
-
-- added support for multiline in personal note field
+* added support for multiline in personal note field
 
 ## 1.3.0
 
 ### Change
-
-- Updating style for /nextStep page (beautify UI)
-- Company Role Step – document download used api endpoint path updated
+* Updating style for /nextStep page (beautify UI)
+* Company Role Step – document download used api endpoint path updated
 
 ### Feature
-
 n/a
 
 ### Technical Support
-
-- added temp fix for CVE-2023-0464
-- added build workflow for v1.3.0 release candidate phase
-- updated actions workflows
+* added temp fix for CVE-2023-0464
+* added build workflow for v1.3.0 release candidate phase
+* updated actions workflows
 
 ### Bugfix
-
 n/a
 
 ## 1.2.0
 
 ### Change
-
-- Visually highlight mandatory company data input fields
-- Update "Submit" registration button to support delays, network latency via loading element
+* Visually highlight mandatory company data input fields
+* Update "Submit" registration button to support delays, network latency via loading element
 
 ### Feature
-
 n/a
 
 ### Technical Support
-
-- Change local port to run behind reverse proxy
+* Change local port to run behind reverse proxy
 
 ### Bugfix
-
 n/a
 
 ## 1.1.0
 
 ### Change
-
-- Updated registration "Submit" button to load button
+* Updated registration "Submit" button to load button
 
 ### Feature
-
-- Company Data - added region field optionally as well as mandatory for a given number of countries
-- Released error page for 4xx and 5xx errors when accessing/loading the registration app
+* Company Data - added region field optionally as well as mandatory for a given number of countries
+* Released error page for 4xx and 5xx errors when accessing/loading the registration app
 
 ### Technical Support
-
-- Added temp fix for CVE-2023-23916
+* Added temp fix for CVE-2023-23916
 
 ### Bugfix
-
-- Company Data - display company name as 'Legal Entity Name' and 'Registered Name'
-- Company Data - errors displayed for "bpn does not exist" reduced to input field error only, additionally style updated
-- Company Data - confirm button disabled till all company data are added
+* Company Data - display company name as 'Legal Entity Name' and 'Registered Name'
+* Company Data - errors displayed for "bpn does not exist" reduced to input field error only, additionally style updated
+* Company Data - confirm button disabled till all company data are added
 
 ## 1.0.0-RC6
 
 ### Change
-
 n/a
 
 ### Feature
-
 n/a
 
 ### Technical Support
-
 n/a
 
 ### Bugfix
-
-- Fix redirect url issue in case of redirection to portal homepage
-- Updated regular expression of street name pattern for company data input field
-- Fix unique identifier display option for bpdm company data autofill
+* Fix redirect url issue in case of redirection to portal homepage
+* Updated regular expression of street name pattern for company data input field
+* Fix unique identifier display option for bpdm company data autofill
 
 ## 1.0.0-RC5
 
 ### Change
-
 n/a
 
 ### Feature
-
-- Redirect user to "closed"; "under validation" or portal page based on application status
+* Redirect user to "closed"; "under validation" or portal page based on application status 
 
 ### Technical Support
-
 n/a
 
 ### Bugfix
-
-- Company Data Unique Identifier field value irritation when entering the unique identifier value
+* Company Data Unique Identifier field value irritation when entering the unique identifier value
 
 ## 1.0.0-RC4
 
 ### Change
-
 n/a
 
 ### Feature
-
 n/a
 
 ### Technical Support
-
-- resolve dependabot finding
-- temp fix for cve-2023-0286
-- add missing '--no-cache': apk update && apk add
+* resolve dependabot finding
+* temp fix for cve-2023-0286
+* add missing '--no-cache': apk update && apk add
 
 ### Bugfix
-
-- Change companyRoleAgreementData API response (new structure of the response body)
-- Company Data Unique Identifier
-  - Identifier type ui issue when entering the value fixed
-  - Identifier number change enabled even after initial save
-  - Identifier number pattern error validation updated (fe)
+* Change companyRoleAgreementData API response (new structure of the response body)
+* Company Data Unique Identifier
+  * Identifier type ui issue when entering the value fixed
+  * Identifier number change enabled even after initial save
+  * Identifier number pattern error validation updated (fe)
 
 ## 1.0.0-RC3
 
 ### Change
-
-- add error pop-up for step 3 - select company role and commit to t&c's
-- city data input pattern updated
+* add error pop-up for step 3 - select company role and commit to t&c's
+* city data input pattern updated
 
 ### Feature
-
 n/a
 
 ### Technical Support
-
 n/a
 
 ### Bugfix
-
-- help page handling
-- CVE-2022-46175 - Prototype Pollution in JSON5 via Parse Method - upgraded all dependencies
+* help page handling
+* CVE-2022-46175 - Prototype Pollution in JSON5 via Parse Method - upgraded all dependencies
 
 ## 1.0.0-RC2
 
 ### Change
-
 n/a
 
 ### Feature
-
-- enabled company data input form to support unique identifier handling for companies based on company location country code. ![Tag](https://img.shields.io/static/v1?label=&message=Pre-Release&color=grey&style=flat)
+* enabled company data input form to support unique identifier handling for companies based on company location country code. ![Tag](https://img.shields.io/static/v1?label=&message=Pre-Release&color=grey&style=flat)
 
 ### Technical Support
-
 n/a
 
 ### Bugfix
-
-- translation fixes on static text values
+* translation fixes on static text values
 
 ## 1.0.0-RC1
 
 ### Change
-
-- implemented in the step 1 "company data" error handling for unsuccessful company data save function
+* implemented in the step 1 "company data" error handling for unsuccessful company data save function
 
 ### Feature
-
 n/a
 
 ### Technical Support
-
 n/a
 
 ### Bugfix
-
 n/a
 
 ## 0.10.0
 
 ### Change
-
-- updated postal code validation for registration step 1 to allow international codes
-- update of company role agreement frontend logic to display agreements with and without documents
+* updated postal code validation for registration step 1 to allow international codes
+* update of company role agreement frontend logic to display agreements with and without documents
 
 ### Feature
-
 n/a
 
 ### Technical Support
-
 n/a
 
 ### Bugfix
-
 n/a
 
 ## 0.9.0
 
 ### Change
-
-- updated document deletion endpoint (from administration service to registration service) and added error/success messages
+* updated document deletion endpoint (from administration service to registration service) and added error/success messages
 
 ### Feature
-
 n/a
 
 ### Technical Support
-
 n/a
 
 ### Bugfix
-
-- Added missing image to the registration finished / successfully submitted page
+* Added missing image to the registration finished / successfully submitted page
 
 ## 0.8.0
 
 ### Change
-
 n/a
 
 ### Feature
-
-- Registration Step 3 (company role and consent agreement); fetching agreement document from the portal backend and enabling direct document download.
+* Registration Step 3 (company role and consent agreement); fetching agreement document from the portal backend and enabling direct document download.
 
 ### Technical Support
-
 n/a
 
 ### Bugfix
-
-- Registration submission validations as well as registration request validation enhanced/fixed.
+* Registration submission validations as well as registration request validation enhanced/fixed.
 
 ## 0.7.0
 
 ### Change
-
 n/a
 
 ### Feature
-
-- Company registration submission for companies without BPN got activated.
+* Company registration submission for companies without BPN got activated.
 
 ### Technical Support
-
 n/a
 
 ### Bugfix
-
-- Registration Step 1 "Company Data Input Form": Country input field updated to country code incl. input validation
+* Registration Step 1 "Company Data Input Form": Country input field updated to country code incl. input validation
 
 ## 0.6.0
 
 ### Change
-
-- n/a
+* n/a
 
 ### Feature
-
-- Registration Welcome: Introduction of a welcome page including a "how to" for the following registration steps
-- Registration Submission: Support of the registration submission incl. new page for successful submission and triggered email to the registrator
-- Registration Closed Function: Company registrations in status "submitted", "approved" or "declined" cannot re-visit the registration document. A closed registration information gets displayed.
+* Registration Welcome: Introduction of a welcome page including a "how to" for the following registration steps
+* Registration Submission: Support of the registration submission incl. new page for successful submission and triggered email to the registrator
+* Registration Closed Function: Company registrations in status "submitted", "approved" or "declined" cannot re-visit the registration document. A closed registration information gets displayed.
 
 ### Technical Support
-
-- n/a
+* n/a
 
 ### Bugfix
-
-- Bugfix - Add company data - payload update to include bpn when posting the company data
-- Bugfix - Submit registration - added applicationId into the post job
-- Bugfix - Company Roles - company role description moved from hardcoded values to api (db)
+* Bugfix - Add company data - payload update to include bpn when posting the company data
+* Bugfix - Submit registration - added applicationId into the post job
+* Bugfix - Company Roles - company role description moved from hardcoded values to api (db)

--- a/src/components/cax-companyData.tsx
+++ b/src/components/cax-companyData.tsx
@@ -167,10 +167,10 @@ export const CompanyDataCax = () => {
   }, [identifierType, identifierNumber, country])
 
   useEffect(() => {
-    setFields(companyDetails);
+    setFields(companyDetails)
   }, [companyDetails])
 
-  const setFields = (bpnDetails: any) =>{
+  const setFields = (bpnDetails: any) => {
     setBpn(bpnDetails?.bpn ?? '')
     setLegalEntity(bpnDetails?.name ?? '')
     setRegisteredName(bpnDetails?.name ?? '')
@@ -387,6 +387,10 @@ export const CompanyDataCax = () => {
     return <Notify message={message} />
   }
 
+  const utfNormalize = (value: string) => {
+    return value.normalize('NFC')
+  }
+
   return (
     <>
       <div className="mx-auto col-9 container-registration">
@@ -452,7 +456,7 @@ export const CompanyDataCax = () => {
                 type="text"
                 value={legalEntity}
                 onChange={(e) => {
-                  validateLegalEntity(e.target.value)
+                  validateLegalEntity(utfNormalize(e.target.value))
                 }}
                 onBlur={(e) => {
                   setLegalEntity(e.target.value.trim())
@@ -475,7 +479,7 @@ export const CompanyDataCax = () => {
                 type="text"
                 value={registeredName}
                 onChange={(e) => {
-                  validateRegisteredName(e.target.value)
+                  validateRegisteredName(utfNormalize(e.target.value))
                 }}
                 onBlur={(e) => {
                   setRegisteredName(e.target.value.trim())
@@ -505,7 +509,7 @@ export const CompanyDataCax = () => {
                 type="text"
                 value={streetHouseNumber}
                 onChange={(e) => {
-                  validateStreetHouseNumber(e.target.value)
+                  validateStreetHouseNumber(utfNormalize(e.target.value))
                 }}
                 onBlur={(e) => {
                   setStreetHouseNumber(e.target.value.trim())
@@ -546,7 +550,7 @@ export const CompanyDataCax = () => {
                 type="text"
                 value={city}
                 onChange={(e) => {
-                  validateCity(e.target.value)
+                  validateCity(utfNormalize(e.target.value))
                 }}
                 onBlur={(e) => {
                   setCity(e.target.value.trim())
@@ -596,7 +600,7 @@ export const CompanyDataCax = () => {
                 type="text"
                 value={region}
                 onChange={(e) => {
-                  validateRegion(e.target.value)
+                  validateRegion(utfNormalize(e.target.value))
                 }}
                 onBlur={(e) => {
                   setRegion(e.target.value.trim())
@@ -689,7 +693,7 @@ export const CompanyDataCax = () => {
                       type="text"
                       value={identifierNumber}
                       onChange={(e) => {
-                        validateIdentifierNumber(e.target.value)
+                        validateIdentifierNumber(utfNormalize(e.target.value))
                       }}
                       onBlur={(e) => {
                         setIdentifierNumber(e.target.value.trim())


### PR DESCRIPTION
## Description

- Added utf normalisation to all text fields on companyData page


Changelog: 

```
  - **Registration Form**
    - added utf normalization on form text fields [#367](https://github.com/eclipse-tractusx/portal-frontend-registration/pull/367)
 ```

## Why

There are some cases where umlaut characters are not being validated. This is happening when text is being copy and pasted from a website or a website from certain bowsers that construct umlaut characters by combining two utf characters instead of using the single uft character of that umlaut. 

For example:

U+0075  + U+0308 = Ü  -> Error

U+00FC = Ü -> Accepted 

Therefore, a function is needed to convert cases where two utf codes are used into a single more universally accepted code. 

## Issue

#365 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
